### PR TITLE
Add AI workflow agreement

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,8 @@ The site is being fully redesigned as a clean, mobile-first food portfolio and l
 
 ## Priorities
 
+- Follow `WORKFLOW.md` for branch, pull request, merge, and task-tracking expectations.
+- Do not merge pull requests. Drake manually reviews and merges PRs.
 - Keep the site simple, fast, accessible, and easy to maintain.
 - Use modern Angular, not legacy AngularJS / Angular 1.x.
 - Favor static or mostly-static architecture.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,6 +343,8 @@ For large redesign work, prefer phases:
 
 When working in this repository:
 
+- Follow `WORKFLOW.md` for branch, pull request, merge, and task-tracking expectations.
+- Do not merge pull requests. Drake manually reviews and merges PRs.
 - Read this file first.
 - Check existing conventions before introducing new ones.
 - Do not assume the current framework beyond the project decision to use modern Angular.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,89 @@
+# WORKFLOW.md - AI Working Agreement
+
+This document defines how AI assistants should collaborate on this repository.
+
+## Default Workflow
+
+- Work on feature branches, not directly on `main`.
+- Keep changes small, reviewable, and aligned with `AGENTS.md`.
+- Update `TODO_STATUS.md` when task status changes.
+- Run relevant validation before opening a PR.
+- Open a pull request when work is ready for review.
+- Do not merge pull requests. Drake manually reviews and merges PRs.
+
+## Git Rules For AI Assistants
+
+AI assistants may, when asked to implement work:
+
+- create or use a feature branch
+- make code/documentation changes
+- commit relevant changes
+- push the feature branch
+- open or update a pull request
+
+AI assistants must not:
+
+- push directly to `main`
+- merge pull requests
+- delete remote branches unless asked
+- force push unless explicitly approved
+- rewrite shared history unless explicitly approved
+- commit secrets, credentials, tokens, private certificates, or real `.env` values
+
+## Pull Request Expectations
+
+Every PR should include:
+
+- a concise summary of changes
+- validation commands that were run
+- any known limitations or follow-up tasks
+- notes about deployment or credential requirements when relevant
+
+If validation cannot be run, state why in the PR description.
+
+## Manual Merge Policy
+
+Drake owns the final merge decision.
+
+Even if CI passes and the PR is mergeable, AI assistants should stop after opening or updating the PR and report:
+
+- PR URL
+- validation status
+- known blockers
+- recommended next steps
+
+## Task Tracking
+
+Use `TODO_STATUS.md` for project status.
+
+When completing, deferring, or discovering work, update the relevant section:
+
+- Completed
+- In Progress
+- Remaining Tasks
+- Notes
+- Last Updated
+
+Do not mark work complete unless it has actually been done and validated where applicable.
+
+## Validation
+
+Before considering implementation complete, run the relevant available checks, such as:
+
+```bash
+npm run typecheck
+npm run build
+```
+
+Only claim validation passed if the commands were actually run.
+
+## When To Ask Drake First
+
+Ask before making changes that affect:
+
+- AWS cost or cloud architecture
+- DNS, certificates, or production deployment behavior
+- public site copy that implies RecipeSensei is launched
+- new dependencies or major framework changes
+- destructive git operations
+- direct changes to `main`

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -6,6 +6,8 @@ The site is being fully redesigned as a clean, mobile-first food portfolio and l
 
 ## Priorities
 
+- Follow `WORKFLOW.md` for branch, pull request, merge, and task-tracking expectations.
+- Do not merge pull requests. Drake manually reviews and merges PRs.
 - Keep the site simple, fast, accessible, and easy to maintain.
 - Use modern Angular, not legacy AngularJS / Angular 1.x.
 - Favor static or mostly-static architecture.


### PR DESCRIPTION
## Summary
- Adds `WORKFLOW.md` with AI collaboration rules for branches, PRs, validation, task tracking, and manual merges.
- Updates `AGENTS.md` and Copilot instruction files to reference the workflow agreement.
- Documents that AI assistants should not merge PRs; Drake manually reviews and merges.

## Validation
- Not run; documentation-only change.