### PR TITLE
Manage deploy IAM policy with OpenTofu

### DIFF
--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -22,13 +22,14 @@
 - [x] HTTPS enabled with CloudFront, ACM, and Route 53
 - [x] Existing S3 bucket imported into OpenTofu state
 - [x] CloudFront distribution ID configured for GitHub Actions invalidations
+- [x] GitHub Actions AWS credentials configured
 - [x] App builds successfully
 - [x] TypeScript type checking passes
 
 ## 🔄 In Progress
 
 - [ ] Image file optimization/compression
-- [ ] Configure GitHub Actions AWS credentials
+- [ ] Apply OpenTofu-managed GitHub Actions deploy IAM policy
 - [ ] Verify first S3 deployment from GitHub Actions
 - [ ] Accessibility audit
 - [ ] SEO metadata and structured data
@@ -67,11 +68,12 @@
 - Gallery images now lazy-load and use fixed aspect ratios for steadier responsive rendering
 - Hero image is prioritized for initial page load
 - GitHub Actions deploys `dist/drakesfood-app/browser` to existing S3 bucket `drakesfood.com` in `us-east-2`
-- GitHub repository still needs AWS deployment secrets before the first live deployment can run
+- GitHub repository has AWS deployment credentials configured
 - HTTPS now serves through CloudFront for `https://drakesfood.com` and `https://www.drakesfood.com`
 - HTTP now redirects to HTTPS through CloudFront
 - CloudFront distribution ID is `ETNCPE8F2TB5D`
 - OpenTofu local state currently manages the imported S3 bucket plus CloudFront, ACM, Route 53, bucket policy, and bucket public access block
+- Latest deployment reached S3 sync but failed CloudFront invalidation because the GitHub Actions IAM user needs `cloudfront:CreateInvalidation`
 - RecipeSensei remains marked as "coming soon" until launch
 - Instagram link remains `https://instagram.com/drakesfood`
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -15,24 +15,38 @@ CloudFront requires ACM certificates to be in `us-east-1`, so this config uses a
 
 ## One-Time Setup
 
-Install OpenTofu, then initialize from this directory with AWS credentials configured for the account that hosts `drakesfood.com`:
+Install OpenTofu, then initialize from this directory with AWS credentials configured for the account that hosts `drakesfood.com`.
+
+For local infrastructure commands, first verify that the `drakesfood` AWS profile is logged in:
 
 ```bash
-tofu init
+aws sts get-caller-identity --profile drakesfood
+```
+
+If that command fails because the SSO session expired, log in again:
+
+```bash
+aws sso login --profile drakesfood
+```
+
+Then run OpenTofu commands with the profile selected:
+
+```bash
+AWS_PROFILE=drakesfood tofu init
 ```
 
 The `drakesfood.com` S3 bucket already exists. Before applying, import it and the existing bucket access settings into state so OpenTofu adopts them instead of trying to create duplicates:
 
 ```bash
-tofu import aws_s3_bucket.site drakesfood.com
-tofu import aws_s3_bucket_public_access_block.site drakesfood.com
-tofu import aws_s3_bucket_policy.site drakesfood.com
+AWS_PROFILE=drakesfood tofu import aws_s3_bucket.site drakesfood.com
+AWS_PROFILE=drakesfood tofu import aws_s3_bucket_public_access_block.site drakesfood.com
+AWS_PROFILE=drakesfood tofu import aws_s3_bucket_policy.site drakesfood.com
 ```
 
 The GitHub Actions deploy IAM user already exists. Import it before applying so OpenTofu manages the user and deploy policy without recreating the user:
 
 ```bash
-tofu import aws_iam_user.github_actions_deploy github-actions-drakesfood-deploy
+AWS_PROFILE=drakesfood tofu import aws_iam_user.github_actions_deploy github-actions-drakesfood-deploy
 ```
 
 OpenTofu manages the IAM user and its deploy policy only. Do not manage deploy access keys with OpenTofu because secret access key material would be stored in state. Keep the access key ID and secret access key in GitHub repository secrets.
@@ -40,20 +54,20 @@ OpenTofu manages the IAM user and its deploy policy only. Do not manage deploy a
 The credentials used for import and apply need permission to read IAM users and create or update IAM user policies. If an inline policy with the same generated name already exists, import it with:
 
 ```bash
-tofu import aws_iam_user_policy.github_actions_deploy github-actions-drakesfood-deploy:github-actions-drakesfood-deploy-policy
+AWS_PROFILE=drakesfood tofu import aws_iam_user_policy.github_actions_deploy github-actions-drakesfood-deploy:github-actions-drakesfood-deploy-policy
 ```
 
 Then preview and apply:
 
 ```bash
-tofu plan
-tofu apply
+AWS_PROFILE=drakesfood tofu plan
+AWS_PROFILE=drakesfood tofu apply
 ```
 
 After apply finishes, get the CloudFront distribution ID:
 
 ```bash
-tofu output -raw cloudfront_distribution_id
+AWS_PROFILE=drakesfood tofu output -raw cloudfront_distribution_id
 ```
 
 Add that value as a GitHub repository variable named `CLOUDFRONT_DISTRIBUTION_ID`.

--- a/infra/README.md
+++ b/infra/README.md
@@ -9,12 +9,13 @@ OpenTofu manages the AWS resources needed to serve `drakesfood.com` over HTTPS.
 - ACM certificate for `drakesfood.com` and `www.drakesfood.com`
 - CloudFront distribution with HTTP-to-HTTPS redirects
 - Route 53 alias records for apex and `www`
+- IAM user policy for GitHub Actions deployment
 
 CloudFront requires ACM certificates to be in `us-east-1`, so this config uses a secondary AWS provider for the certificate while keeping the existing S3 bucket in `us-east-2`.
 
 ## One-Time Setup
 
-Install OpenTofu, then initialize from this directory:
+Install OpenTofu, then initialize from this directory with AWS credentials configured for the account that hosts `drakesfood.com`:
 
 ```bash
 tofu init
@@ -26,6 +27,20 @@ The `drakesfood.com` S3 bucket already exists. Before applying, import it and th
 tofu import aws_s3_bucket.site drakesfood.com
 tofu import aws_s3_bucket_public_access_block.site drakesfood.com
 tofu import aws_s3_bucket_policy.site drakesfood.com
+```
+
+The GitHub Actions deploy IAM user already exists. Import it before applying so OpenTofu manages the user and deploy policy without recreating the user:
+
+```bash
+tofu import aws_iam_user.github_actions_deploy github-actions-drakesfood-deploy
+```
+
+OpenTofu manages the IAM user and its deploy policy only. Do not manage deploy access keys with OpenTofu because secret access key material would be stored in state. Keep the access key ID and secret access key in GitHub repository secrets.
+
+The credentials used for import and apply need permission to read IAM users and create or update IAM user policies. If an inline policy with the same generated name already exists, import it with:
+
+```bash
+tofu import aws_iam_user_policy.github_actions_deploy github-actions-drakesfood-deploy:github-actions-drakesfood-deploy-policy
 ```
 
 Then preview and apply:
@@ -55,6 +70,14 @@ It also needs this GitHub repository variable:
 - `CLOUDFRONT_DISTRIBUTION_ID`
 
 The AWS credentials must be allowed to sync files to the S3 bucket and create CloudFront invalidations. Until `CLOUDFRONT_DISTRIBUTION_ID` is configured, the deploy workflow will still sync to S3 but will skip CloudFront invalidation.
+
+The OpenTofu-managed deploy policy grants the GitHub Actions IAM user these permissions:
+
+- `s3:ListBucket` on the site bucket
+- `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` on site bucket objects
+- `cloudfront:CreateInvalidation` on the site CloudFront distribution
+
+If older manually attached deploy policies exist on the IAM user, review and remove them after `tofu apply` confirms the OpenTofu-managed policy is active.
 
 ## Expected Result
 

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,0 +1,49 @@
+resource "aws_iam_user" "github_actions_deploy" {
+  name = var.github_actions_deploy_user_name
+}
+
+data "aws_iam_policy_document" "github_actions_deploy" {
+  statement {
+    sid = "ListSiteBucket"
+
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      aws_s3_bucket.site.arn,
+    ]
+  }
+
+  statement {
+    sid = "SyncSiteAssets"
+
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.site.arn}/*",
+    ]
+  }
+
+  statement {
+    sid = "InvalidateSiteDistribution"
+
+    actions = [
+      "cloudfront:CreateInvalidation",
+    ]
+
+    resources = [
+      aws_cloudfront_distribution.site.arn,
+    ]
+  }
+}
+
+resource "aws_iam_user_policy" "github_actions_deploy" {
+  name   = "${var.github_actions_deploy_user_name}-policy"
+  user   = aws_iam_user.github_actions_deploy.name
+  policy = data.aws_iam_policy_document.github_actions_deploy.json
+}

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,5 +1,9 @@
 resource "aws_iam_user" "github_actions_deploy" {
   name = var.github_actions_deploy_user_name
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 data "aws_iam_policy_document" "github_actions_deploy" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -21,3 +21,9 @@ variable "s3_bucket_name" {
   type        = string
   default     = "drakesfood.com"
 }
+
+variable "github_actions_deploy_user_name" {
+  description = "IAM user used by GitHub Actions to deploy the static site. Access keys are managed outside OpenTofu."
+  type        = string
+  default     = "github-actions-drakesfood-deploy"
+}


### PR DESCRIPTION
## Summary
- Adds OpenTofu management for the existing GitHub Actions deploy IAM user.
- Adds a least-privilege inline deploy policy for S3 sync and CloudFront invalidation.
- Documents AWS SSO login checks, IAM user/policy import steps, and keeps access keys outside OpenTofu state.
- Updates TODO status to reflect that credentials are configured but the deploy IAM policy still needs to be applied.

## Validation
- `aws sts get-caller-identity --profile drakesfood`
- `AWS_PROFILE=drakesfood tofu import aws_iam_user.github_actions_deploy github-actions-drakesfood-deploy`
- `tofu fmt -check`
- `tofu validate`
- `AWS_PROFILE=drakesfood tofu plan`

## Plan Result
- Import succeeded for `aws_iam_user.github_actions_deploy`.
- Current plan is `1 to add, 0 to change, 0 to destroy`.
- The planned addition is `aws_iam_user_policy.github_actions_deploy`, granting S3 sync permissions and `cloudfront:CreateInvalidation` for distribution `ETNCPE8F2TB5D`.

## Notes
- Do not manage `aws_iam_access_key` in OpenTofu; keep access keys in GitHub repository secrets.
- I did not run `tofu apply`; Drake should review/merge and explicitly approve apply.