### PR TITLE
Opt GitHub Actions into Node 24

### DIFF
--- a/.github/workflows/angular-ci.yml
+++ b/.github/workflows/angular-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   AWS_REGION: us-east-2
   S3_BUCKET: drakesfood.com
   CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}


### PR DESCRIPTION
## Summary
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to CI and deploy workflows.
- Keeps Angular build execution on the Node version pinned by `.nvmrc` via `actions/setup-node`.
- Addresses GitHub's Node.js 20 JavaScript action runtime deprecation warning.

## Validation
- Not run; workflow configuration-only change.

## Notes
- This affects the runtime for JavaScript actions such as `actions/checkout` and `aws-actions/configure-aws-credentials`, not the app build Node version.