### PR TITLE
Update workflows to Node 24-native actions

### DIFF
--- a/.github/workflows/angular-ci.yml
+++ b/.github/workflows/angular-ci.yml
@@ -6,14 +6,11 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js 22
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   AWS_REGION: us-east-2
   S3_BUCKET: drakesfood.com
   CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
@@ -21,7 +20,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js 22
         uses: actions/setup-node@v5
@@ -39,7 +38,7 @@ jobs:
         run: npm run build
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -23,14 +23,15 @@
 - [x] Existing S3 bucket imported into OpenTofu state
 - [x] CloudFront distribution ID configured for GitHub Actions invalidations
 - [x] GitHub Actions AWS credentials configured
+- [x] OpenTofu-managed GitHub Actions deploy IAM policy applied
+- [x] First S3 deployment from GitHub Actions verified
 - [x] App builds successfully
 - [x] TypeScript type checking passes
 
 ## 🔄 In Progress
 
 - [ ] Image file optimization/compression
-- [ ] Apply OpenTofu-managed GitHub Actions deploy IAM policy
-- [ ] Verify first S3 deployment from GitHub Actions
+- [ ] Upgrade GitHub Actions workflows to Node 24-native action versions
 - [ ] Accessibility audit
 - [ ] SEO metadata and structured data
 
@@ -73,7 +74,8 @@
 - HTTP now redirects to HTTPS through CloudFront
 - CloudFront distribution ID is `ETNCPE8F2TB5D`
 - OpenTofu local state currently manages the imported S3 bucket plus CloudFront, ACM, Route 53, bucket policy, and bucket public access block
-- Latest deployment reached S3 sync but failed CloudFront invalidation because the GitHub Actions IAM user needs `cloudfront:CreateInvalidation`
+- Latest deployment succeeded, including S3 sync and CloudFront invalidation for distribution `ETNCPE8F2TB5D`
+- GitHub Actions workflows are being updated from temporary Node 24 forcing to Node 24-native action versions
 - RecipeSensei remains marked as "coming soon" until launch
 - Instagram link remains `https://instagram.com/drakesfood`
 


### PR DESCRIPTION
## Summary
- Updates GitHub Actions workflows to use Node 24-native action versions.
- Removes the temporary `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` override.
- Updates `TODO_STATUS.md` with the verified successful S3 deploy and CloudFront invalidation.

## Validation
- `npm run typecheck`
- `npm run build`

## Notes
- Local build completed with Node `v25.9.0`, which Angular warns is not LTS. GitHub Actions continues to use `.nvmrc` Node 22.
- The deploy workflow itself will be fully verified after this PR is merged to `main`, since deploy only runs on `main` pushes.