### PR TITLE
Add SEO metadata

### DIFF
--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -28,12 +28,13 @@
 - [x] Upgrade GitHub Actions workflows to Node 24-native action versions
 - [x] Accessibility audit and core accessibility fixes
 - [x] Image file optimization/compression
+- [x] SEO metadata and structured data
 - [x] App builds successfully
 - [x] TypeScript type checking passes
 
 ## 🔄 In Progress
 
-- [ ] SEO metadata and structured data
+- [ ] Add build/lint/test validation in CI
 
 ## 📋 Remaining Tasks
 
@@ -78,6 +79,7 @@
 - Latest deployment succeeded, including S3 sync and CloudFront invalidation for distribution `ETNCPE8F2TB5D`
 - GitHub Actions workflows now use Node 24-native action versions without the temporary Node 24 override
 - Accessibility pass added a main landmark, skip link, visible focus states, reduced-motion handling, section labels, clearer external link labels, and improved RecipeSensei badge contrast
+- Static SEO pass added canonical URL, robots metadata, Open Graph and Twitter card tags, and WebSite JSON-LD
 - RecipeSensei remains marked as "coming soon" until launch
 - Instagram link remains `https://instagram.com/drakesfood`
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -4,6 +4,8 @@ This document defines how AI assistants should collaborate on this repository.
 
 ## Default Workflow
 
+- Before making code or documentation changes, check the current branch with `git branch --show-current`.
+- If the current branch is `main`, create or switch to a feature branch before editing.
 - Work on feature branches, not directly on `main`.
 - Keep changes small, reviewable, and aligned with `AGENTS.md`.
 - Update `TODO_STATUS.md` when task status changes.

--- a/src/index.html
+++ b/src/index.html
@@ -2,10 +2,43 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Drake's Food</title>
+  <title>Drake's Food | Food Photography & Home Cooking</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Drake's Food is a clean, photo-first portfolio for food photography, Instagram, and RecipeSensei inspiration.">
+  <meta name="description" content="Drake's Food is a warm, photo-first home for food photography, home cooking, Instagram updates, and RecipeSensei inspiration.">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://drakesfood.com/">
+
+  <meta property="og:title" content="Drake's Food | Food Photography & Home Cooking">
+  <meta property="og:description" content="A warm, photo-first home for Drake's food photography, home cooking, Instagram updates, and RecipeSensei inspiration.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://drakesfood.com/">
+  <meta property="og:site_name" content="Drake's Food">
+  <meta property="og:image" content="https://drakesfood.com/assets/images/markaritaOoniPizza.jpeg">
+  <meta property="og:image:alt" content="Margarita pizza fresh from the Ooni oven with melted mozzarella and basil">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Drake's Food | Food Photography & Home Cooking">
+  <meta name="twitter:description" content="A warm, photo-first home for Drake's food photography, home cooking, Instagram updates, and RecipeSensei inspiration.">
+  <meta name="twitter:image" content="https://drakesfood.com/assets/images/markaritaOoniPizza.jpeg">
+  <meta name="twitter:image:alt" content="Margarita pizza fresh from the Ooni oven with melted mozzarella and basil">
+
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "Drake's Food",
+      "url": "https://drakesfood.com/",
+      "description": "A warm, photo-first home for food photography, home cooking, Instagram updates, and RecipeSensei inspiration.",
+      "publisher": {
+        "@type": "Person",
+        "name": "Drake",
+        "sameAs": [
+          "https://instagram.com/drakesfood"
+        ]
+      }
+    }
+  </script>
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Add canonical, robots, Open Graph, Twitter card, and JSON-LD metadata to the static Angular entry page.
- Mark SEO metadata work complete and move CI validation to the active next TODO.
- Strengthen the workflow guidance to check/switch off `main` before editing.

## Validation
- `npm run typecheck` passed
- `npm run build` passed
- Drake manually ran a build and verified the changes

## Notes
- Local build still reports the existing odd-numbered Node warning for Node v25.9.0, but the build completes successfully.