### PR TITLE
Add purple visual branding

### DIFF
--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -31,6 +31,7 @@
 - [x] SEO metadata and structured data
 - [x] ESLint lint configuration
 - [x] Build/lint/typecheck validation in CI
+- [x] Purple visual theme accents and ninja chef mascot
 - [x] App builds successfully
 - [x] TypeScript type checking passes
 
@@ -44,6 +45,7 @@
 
 - [ ] Finalize copy for all sections
 - [ ] Add more gallery images or full gallery page (deferred for now)
+- [ ] Replace temporary ninja chef SVG with a stronger ChatGPT-generated mascot asset
 - [ ] Add RecipeSensei launch details once available
 - [ ] Refine About section content
 - [ ] Add optional recipe/blog details page later
@@ -87,6 +89,8 @@
 - Angular test runner setup remains deferred and tracked separately
 - RecipeSensei remains marked as "coming soon" until launch
 - Instagram link remains `https://instagram.com/drakesfood`
+- Purple theme accents now use shared CSS variables, with a ninja chef mascot in the hero and SVG favicon support
+- Current ninja chef mascot is a temporary placeholder; use SVG if the next mascot is simple/logo-like, or transparent PNG if it is more detailed/illustrative
 
 ## Last Updated
 

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Drake's Food ninja chef icon">
+  <defs>
+    <linearGradient id="bg" x1="8" x2="56" y1="8" y2="56" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#eee7fb" />
+      <stop offset="1" stop-color="#d9c8f7" />
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="30" fill="url(#bg)" />
+  <path fill="#3d256f" d="M16 29c0-12 7-20 17-20 9 0 16 8 16 20 0 8-2 14-7 19H23c-5-5-7-11-7-19Z" />
+  <path fill="#fffaf5" d="M20 27c4-4 8-5 13-5 4 0 8 1 12 5-2 6-6 9-13 9s-11-3-12-9Z" />
+  <circle cx="27" cy="29" r="2" fill="#32221b" />
+  <circle cx="38" cy="29" r="2" fill="#32221b" />
+  <path fill="#ffffff" d="M23 41h20l4 13c-4 3-9 5-15 5s-11-2-15-5l6-13Z" />
+  <path fill="#f6f8fb" d="M46 19 59 6c1-1 3 0 3 2l-2 10-11 4-3-3Z" />
+  <path fill="#32221b" d="M42 23c-1-1-1-2 0-3l2-2 6 6-2 2c-1 1-2 1-3 0l-3-3Z" />
+  <circle cx="32" cy="32" r="30" fill="none" stroke="#6d4aa3" stroke-opacity="0.35" stroke-width="3" />
+</svg>

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -3,8 +3,8 @@
 }
 
 .page-shell {
-  background: #f7efe7;
-  color: #32221b;
+  background: transparent;
+  color: var(--color-text);
 }
 
 .skip-link {
@@ -14,7 +14,7 @@
   z-index: 100;
   transform: translateY(-200%);
   border-radius: 999px;
-  background: #32221b;
+  background: var(--color-purple-dark);
   color: #fff;
   padding: 0.75rem 1rem;
   font-weight: 700;
@@ -40,17 +40,27 @@ button,
   border-radius: 999px;
   text-decoration: none;
   cursor: pointer;
+  font-weight: 700;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    background-color 160ms ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
 }
 
 .button-primary {
-  background: #8c5a40;
+  background: linear-gradient(135deg, var(--color-purple), var(--color-clay));
   color: #fff;
   padding: 0.95rem 1.6rem;
+  box-shadow: 0 14px 28px rgba(61, 37, 111, 0.18);
 }
 
 .button-secondary {
-  background: rgba(140, 90, 64, 0.1);
-  color: #8c5a40;
+  background: var(--color-purple-wash);
+  color: var(--color-purple-dark);
   padding: 0.95rem 1.6rem;
 }
 

--- a/src/app/components/about/about.component.css
+++ b/src/app/components/about/about.component.css
@@ -14,6 +14,6 @@
 .about p {
   margin-top: 1.25rem;
   max-width: 46rem;
-  color: #5e4b3f;
+  color: var(--color-text-muted);
   line-height: 1.9;
 }

--- a/src/app/components/footer/footer.component.css
+++ b/src/app/components/footer/footer.component.css
@@ -1,13 +1,13 @@
 .site-footer {
   padding: 2rem 1rem 3rem;
   text-align: center;
-  color: #6f5848;
+  color: var(--color-text-soft);
 }
 
 .site-footer .footer-link {
   display: inline-block;
   margin-top: 0.75rem;
-  color: #3b1f0f;
+  color: var(--color-purple-dark);
   font-weight: 700;
 }
 

--- a/src/app/components/gallery-preview/gallery-preview.component.css
+++ b/src/app/components/gallery-preview/gallery-preview.component.css
@@ -10,7 +10,7 @@
 
 .gallery-header p {
   margin: 0;
-  color: #4d3b30;
+  color: var(--color-text-muted);
   line-height: 1.8;
 }
 
@@ -22,10 +22,11 @@
 }
 
 .gallery-card {
-  background: #fff;
+  background: var(--color-surface);
+  border: 1px solid rgba(109, 74, 163, 0.09);
   border-radius: 1.5rem;
   overflow: hidden;
-  box-shadow: 0 18px 40px rgba(61, 45, 33, 0.08);
+  box-shadow: var(--shadow-card);
 }
 
 .gallery-card img {
@@ -46,7 +47,7 @@
 
 .gallery-copy p {
   margin: 0;
-  color: #5e4b3f;
+  color: var(--color-text-muted);
   line-height: 1.7;
 }
 

--- a/src/app/components/hero/hero.component.css
+++ b/src/app/components/hero/hero.component.css
@@ -9,12 +9,25 @@
   max-width: 640px;
 }
 
-.eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.22em;
-  font-size: 0.78rem;
+.brand-kicker {
+  display: inline-flex;
+  gap: 0.8rem;
+  align-items: center;
   margin-bottom: 0.75rem;
-  color: #7b5f4c;
+  border: 1px solid rgba(109, 74, 163, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 250, 245, 0.72);
+  padding: 0.45rem 1rem 0.45rem 0.45rem;
+  box-shadow: 0 12px 28px rgba(61, 37, 111, 0.08);
+}
+
+.brand-kicker img {
+  width: 3.2rem;
+  height: 3.2rem;
+}
+
+.eyebrow {
+  margin: 0;
 }
 
 .hero h1 {
@@ -24,11 +37,11 @@
   letter-spacing: -0.05rem;
 }
 
-.hero p {
+.hero-content > p {
   margin: 1.25rem 0 0;
   max-width: 40rem;
   line-height: 1.85;
-  color: #4d3b30;
+  color: var(--color-text-muted);
 }
 
 .hero-actions {
@@ -43,7 +56,7 @@
   aspect-ratio: 4 / 5;
   border-radius: 1.5rem;
   object-fit: cover;
-  box-shadow: 0 24px 60px rgba(61, 45, 33, 0.12);
+  box-shadow: var(--shadow-photo);
 }
 
 @media (min-width: 900px) {

--- a/src/app/components/hero/hero.component.html
+++ b/src/app/components/hero/hero.component.html
@@ -1,6 +1,9 @@
 <section class="hero" aria-labelledby="hero-title">
   <div class="hero-content">
-    <p class="eyebrow">Drake's Food</p>
+    <div class="brand-kicker">
+      <img src="assets/images/chef-ninja.svg" alt="Drake's Food ninja chef mascot" width="72" height="72" />
+      <p class="eyebrow">Drake's Food</p>
+    </div>
     <h1 id="hero-title">Every plate tells a story.</h1>
     <p>Warm, photo-first food styling, home cooking, and a first look at RecipeSensei inspiration.</p>
     <div class="hero-actions">

--- a/src/app/components/instagram-cta/instagram-cta.component.css
+++ b/src/app/components/instagram-cta/instagram-cta.component.css
@@ -5,7 +5,10 @@
 .instagram-card {
   display: grid;
   gap: 1.5rem;
-  background: #ffffff;
+  background:
+    linear-gradient(135deg, rgba(109, 74, 163, 0.1), transparent 38%),
+    var(--color-surface);
+  border: 1px solid rgba(109, 74, 163, 0.1);
   border-radius: 1.75rem;
   padding: 2rem;
   box-shadow: 0 20px 56px rgba(61, 45, 33, 0.09);
@@ -18,7 +21,7 @@
 
 .instagram-card p {
   margin: 0;
-  color: #5e4b3f;
+  color: var(--color-text-muted);
   line-height: 1.8;
 }
 

--- a/src/app/components/recipe-blog/recipe-blog.component.css
+++ b/src/app/components/recipe-blog/recipe-blog.component.css
@@ -5,6 +5,6 @@
 .recipe-blog p {
   max-width: 54rem;
   margin-top: 1rem;
-  color: #5e4b3f;
+  color: var(--color-text-muted);
   line-height: 1.8;
 }

--- a/src/app/components/recipe-sensei/recipe-sensei.component.css
+++ b/src/app/components/recipe-sensei/recipe-sensei.component.css
@@ -6,14 +6,15 @@
   display: grid;
   gap: 1.5rem;
   padding: 2rem;
-  background: #fff;
+  background: var(--color-surface);
+  border: 1px solid rgba(109, 74, 163, 0.1);
   border-radius: 1.5rem;
-  box-shadow: 0 18px 42px rgba(61, 45, 33, 0.08);
+  box-shadow: var(--shadow-card);
 }
 
 .teaser-card p {
   margin: 0;
-  color: #5e4b3f;
+  color: var(--color-text-muted);
   line-height: 1.8;
 }
 
@@ -21,8 +22,8 @@
   display: inline-flex;
   padding: 0.8rem 1.2rem;
   border-radius: 999px;
-  background: #f2e0d5;
-  color: #7d4c35;
+  background: var(--color-purple-soft);
+  color: var(--color-purple-dark);
   font-weight: 700;
   font-size: 0.95rem;
   justify-self: start;

--- a/src/assets/images/chef-ninja.svg
+++ b/src/assets/images/chef-ninja.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title description">
+  <title id="title">Drake's Food ninja chef mascot</title>
+  <desc id="description">A friendly ninja chef wearing a white apron and holding a chef knife.</desc>
+  <defs>
+    <linearGradient id="purpleBg" x1="20" x2="140" y1="20" y2="140" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#eee7fb" />
+      <stop offset="1" stop-color="#d9c8f7" />
+    </linearGradient>
+    <linearGradient id="mask" x1="46" x2="116" y1="34" y2="122" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4b2d82" />
+      <stop offset="1" stop-color="#2b1a4d" />
+    </linearGradient>
+  </defs>
+  <circle cx="80" cy="80" r="74" fill="url(#purpleBg)" />
+  <path fill="#f7efe7" d="M42 113c5-24 21-38 39-38s34 14 39 38c-10 12-23 18-40 18s-29-6-38-18Z" />
+  <path fill="url(#mask)" d="M39 72c0-28 18-48 42-48 23 0 40 20 40 48 0 18-5 33-16 44H56C45 105 39 90 39 72Z" />
+  <path fill="#2b1a4d" d="M111 47c10 0 18 9 19 22-9-5-18-9-28-10l9-12Z" />
+  <path fill="#fffaf5" d="M51 66c8-8 19-12 31-12 11 0 21 4 29 12-5 15-15 22-30 22-16 0-26-7-30-22Z" />
+  <circle cx="67" cy="70" r="4.5" fill="#32221b" />
+  <circle cx="94" cy="70" r="4.5" fill="#32221b" />
+  <path fill="none" stroke="#8c5a40" stroke-linecap="round" stroke-width="4" d="M72 82c5 3 11 3 16 0" />
+  <path fill="#ffffff" d="M56 99h50l9 30c-9 8-21 12-35 12-13 0-25-4-34-12l10-30Z" />
+  <path fill="none" stroke="#d9c8f7" stroke-linecap="round" stroke-width="4" d="M68 105v31M93 105v31" />
+  <path fill="#8c5a40" d="M50 111c-8 7-16 8-23 2-3-3-3-8 0-11 4-4 9-4 13 0 3 3 6 6 10 9Z" />
+  <path fill="#8c5a40" d="M110 111c7 5 15 4 21-3 3-4 3-9-1-12-4-3-9-2-12 2-2 4-5 8-8 13Z" />
+  <path fill="#d9dde7" d="M117 50 142 25c3-3 8-1 8 3 0 1-1 3-2 4l-25 25-6-7Z" />
+  <path fill="#f6f8fb" d="M112 45 142 15c3-3 8 0 7 4l-6 25-24 9-7-8Z" />
+  <path fill="#32221b" d="M104 54c-2-2-2-5 0-7l5-5 15 15-5 5c-2 2-5 2-7 0l-8-8Z" />
+  <circle cx="80" cy="80" r="74" fill="none" stroke="#6d4aa3" stroke-opacity="0.25" stroke-width="6" />
+</svg>

--- a/src/index.html
+++ b/src/index.html
@@ -44,7 +44,8 @@
       }
     }
   </script>
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="alternate icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
   <app-root></app-root>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,8 +3,21 @@
 :root {
   color-scheme: light;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: #f7efe7;
-  color: #32221b;
+  --color-background: #f7efe7;
+  --color-surface: #fffaf5;
+  --color-text: #32221b;
+  --color-text-muted: #5e4b3f;
+  --color-text-soft: #6f5848;
+  --color-clay: #8c5a40;
+  --color-clay-dark: #7d4c35;
+  --color-purple: #6d4aa3;
+  --color-purple-dark: #3d256f;
+  --color-purple-soft: #eee7fb;
+  --color-purple-wash: rgba(109, 74, 163, 0.12);
+  --shadow-card: 0 18px 42px rgba(61, 45, 33, 0.08);
+  --shadow-photo: 0 24px 60px rgba(61, 45, 33, 0.12);
+  background: var(--color-background);
+  color: var(--color-text);
 }
 
 * {
@@ -18,7 +31,9 @@ html {
 body {
   margin: 0;
   min-height: 100vh;
-  background: #f7efe7;
+  background:
+    radial-gradient(circle at top left, rgba(109, 74, 163, 0.14), transparent 24rem),
+    var(--color-background);
 }
 
 img {
@@ -33,12 +48,20 @@ a {
 a:focus-visible,
 button:focus-visible,
 .button:focus-visible {
-  outline: 3px solid #3b1f0f;
+  outline: 3px solid var(--color-purple-dark);
   outline-offset: 4px;
 }
 
 p {
   margin: 0;
+}
+
+.eyebrow {
+  color: var(--color-purple-dark);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Adds shared purple theme tokens and applies restrained purple accents across buttons, cards, focus states, and badges.
- Adds a temporary ninja chef SVG mascot in the hero plus SVG favicon support.
- Tracks follow-up work to replace the temporary mascot with a stronger ChatGPT-generated asset.

## Validation
- npm run lint
- npm run typecheck
- npm run build

## Visual Review
- Drake reviewed locally and said the visual update looks good.

## Notes
- Local validation emitted a Node warning because this machine is using Node v25.9.0 while the repo expects Node 22 LTS, but all checks passed.
- The mascot is intentionally temporary; SVG is preferred for a simple/logo-like replacement, while transparent PNG is better for a detailed generated illustration.