### PR TITLE
Add recipe submission infrastructure

### DIFF
--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -36,10 +36,11 @@
 - [x] Responsive testing on mobile/tablet/desktop
 - [x] App builds successfully
 - [x] TypeScript type checking passes
+- [x] Recipe submission API contract documented
 
 ## 🔄 In Progress
 
-- [ ] Define recipe submission API contract — #25
+- [ ] Add recipe submission AWS infrastructure — #26
 - [ ] Conduct performance and accessibility review — #17
 
 ## 📋 Remaining Tasks
@@ -53,7 +54,7 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - [ ] Add RecipeSensei launch details once available — #21
 - [ ] Refine About section content — #16
 - [ ] Add optional recipe/blog details page later — #22
-- [ ] Add recipe submission backend, API wiring, security, and docs — #26-#31
+- [ ] Add recipe submission Lambda, API wiring, security, email, and docs — #27-#31
 
 ### Deployment & Infrastructure
 
@@ -95,7 +96,8 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - RecipeSensei remains marked as "coming soon" until launch
 - Instagram link remains `https://instagram.com/drakesfood`
 - Recipe submissions are starting with a frontend-only form section; live API wiring remains a follow-up.
-- Recipe submission API contract is being documented before backend and infrastructure implementation.
+- Recipe submission API contract is documented before backend and infrastructure implementation.
+- Recipe submission infrastructure is being added with OpenTofu using API Gateway, Lambda, DynamoDB, SES permissions, and CloudWatch logs.
 - Generic `/favicon.ico` and `/favicon.png` fallbacks should match the named chef-ninja favicon files for browsers that request default favicon paths directly.
 - Purple theme accents now use shared CSS variables, with a ninja chef mascot in the hero and SVG favicon support
 - Ninja chef mascot now uses a transparent PNG generated with ChatGPT, resized to 128px for the hero and 192px for the favicon

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,6 +1,24 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/hashicorp/archive" {
+  version     = "2.7.1"
+  constraints = "~> 2.4"
+  hashes = [
+    "h1:/Y6fLmEGMtbcAFi3ALu5tAwEIfUc8vGZRErNjMIfi2U=",
+    "zh:4f8fe5f92125fc7be91379dbde004aaf676fbb523082af167d0a57ac723836bc",
+    "zh:4fba9a08c254fd3c17464c1e13398e4927b1d3e22bfdc3bb66c4e5bd9573ada4",
+    "zh:65e9945c1e89333b01ef25c15518e125817268f9ecddc3f9d5337dc120d342ee",
+    "zh:6cc92ec02475310612a2fc663ab22366c17005203be55287e9af316ac0397ef4",
+    "zh:7e9efa56a27ea28c7a19465b4223f43653988639123160b09507cbc7a9ad5458",
+    "zh:9c77863b5ff47196cec4e82ce9b943c8a0de5840f7b1f82c7e96d92d8be7c7c1",
+    "zh:b6498ff9e2e717c94e5d2c494a2071acc123e8195bfdd9f7965a0676fa866b06",
+    "zh:c5941326ffe88ff77d15fb1212f746ea57eebf7556bc2707c3a054ad0e5a6ab0",
+    "zh:ec1c14feeeb3b78be2ab37533c6ef2e0d6417c6faa82ddd62c446db77f618926",
+    "zh:ed4643c4f8d9f7d060c01463317d68315b6af7197beaba331451ca3991a9c990",
+  ]
+}
+
 provider "registry.opentofu.org/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"

--- a/infra/README.md
+++ b/infra/README.md
@@ -10,8 +10,40 @@ OpenTofu manages the AWS resources needed to serve `drakesfood.com` over HTTPS.
 - CloudFront distribution with HTTP-to-HTTPS redirects
 - Route 53 alias records for apex and `www`
 - IAM user policy for GitHub Actions deployment
+- API Gateway HTTP API for recipe submissions
+- Lambda function, execution role, and CloudWatch logs for recipe submissions
+- DynamoDB table for recipe submission storage
+- SES send permissions for recipe submission notifications
 
 CloudFront requires ACM certificates to be in `us-east-1`, so this config uses a secondary AWS provider for the certificate while keeping the existing S3 bucket in `us-east-2`.
+
+## Recipe Submissions
+
+The recipe submission backend is defined as low-cost serverless infrastructure:
+
+- API Gateway HTTP API exposes `POST /recipe-submissions`.
+- CORS is restricted to `drakesfood.com`, `www.drakesfood.com`, and local Angular development by default.
+- Lambda receives the table name, source site, allowed origins, and SES sender/recipient values through environment variables.
+- DynamoDB stores accepted submissions by `submissionId`.
+- CloudWatch log groups use the configured retention period.
+
+Issue #26 only defines the infrastructure. The Lambda source at `lambda/recipe-submissions/index.mjs` is a placeholder so OpenTofu can package and validate the function before issue #27 adds real submission handling.
+
+Before applying recipe submission infrastructure for production, set these values with a local `.tfvars` file or `-var` arguments. The SES identity ARN can be omitted if the verified identity is the site domain in the active AWS account.
+
+```hcl
+recipe_submissions_ses_identity_arn    = "arn:aws:ses:us-east-2:<account-id>:identity/drakesfood.com"
+recipe_submissions_ses_sender_email    = "<verified-sender-email>"
+recipe_submissions_ses_recipient_email = "<recipient-email>"
+```
+
+Do not commit real email addresses or account-specific values unless they are intentionally public. The SES sender identity must be verified before email notifications can work.
+
+After apply, get the API endpoint for frontend configuration:
+
+```bash
+AWS_PROFILE=drakesfood tofu output -raw recipe_submissions_api_endpoint
+```
 
 ## One-Time Setup
 

--- a/infra/lambda/recipe-submissions/index.mjs
+++ b/infra/lambda/recipe-submissions/index.mjs
@@ -1,0 +1,10 @@
+export const handler = async () => ({
+  statusCode: 501,
+  headers: {
+    'content-type': 'application/json',
+  },
+  body: JSON.stringify({
+    success: false,
+    message: 'Recipe submissions are not connected yet.',
+  }),
+});

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -17,3 +17,18 @@ output "certificate_arn" {
   description = "ACM certificate ARN used by CloudFront."
   value       = aws_acm_certificate.site.arn
 }
+
+output "recipe_submissions_api_endpoint" {
+  description = "Base endpoint URL for the recipe submission HTTP API."
+  value       = aws_apigatewayv2_api.recipe_submissions.api_endpoint
+}
+
+output "recipe_submissions_table_name" {
+  description = "DynamoDB table used for accepted recipe submissions."
+  value       = aws_dynamodb_table.recipe_submissions.name
+}
+
+output "recipe_submissions_lambda_function_name" {
+  description = "Lambda function that handles recipe submissions."
+  value       = aws_lambda_function.recipe_submissions.function_name
+}

--- a/infra/recipe_submissions.tf
+++ b/infra/recipe_submissions.tf
@@ -1,0 +1,178 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  recipe_submissions_ses_identity_arn = var.recipe_submissions_ses_identity_arn != "" ? var.recipe_submissions_ses_identity_arn : "arn:aws:ses:${var.aws_region}:${data.aws_caller_identity.current.account_id}:identity/${var.domain_name}"
+}
+
+resource "aws_dynamodb_table" "recipe_submissions" {
+  name         = var.recipe_submissions_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "submissionId"
+
+  attribute {
+    name = "submissionId"
+    type = "S"
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+}
+
+resource "aws_cloudwatch_log_group" "recipe_submissions_lambda" {
+  name              = "/aws/lambda/${var.recipe_submissions_lambda_function_name}"
+  retention_in_days = var.recipe_submissions_log_retention_days
+}
+
+resource "aws_cloudwatch_log_group" "recipe_submissions_api" {
+  name              = "/aws/apigateway/${var.recipe_submissions_api_name}"
+  retention_in_days = var.recipe_submissions_log_retention_days
+}
+
+data "aws_iam_policy_document" "recipe_submissions_lambda_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "recipe_submissions_lambda" {
+  name               = "${var.recipe_submissions_lambda_function_name}-role"
+  assume_role_policy = data.aws_iam_policy_document.recipe_submissions_lambda_assume_role.json
+}
+
+data "aws_iam_policy_document" "recipe_submissions_lambda" {
+  statement {
+    sid = "WriteRecipeSubmissions"
+
+    actions = [
+      "dynamodb:PutItem",
+    ]
+
+    resources = [
+      aws_dynamodb_table.recipe_submissions.arn,
+    ]
+  }
+
+  statement {
+    sid = "SendRecipeSubmissionEmail"
+
+    actions = [
+      "ses:SendEmail",
+      "ses:SendRawEmail",
+    ]
+
+    resources = [local.recipe_submissions_ses_identity_arn]
+  }
+
+  statement {
+    sid = "WriteLambdaLogs"
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.recipe_submissions_lambda.arn}:*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "recipe_submissions_lambda" {
+  name   = "${var.recipe_submissions_lambda_function_name}-policy"
+  role   = aws_iam_role.recipe_submissions_lambda.id
+  policy = data.aws_iam_policy_document.recipe_submissions_lambda.json
+}
+
+data "archive_file" "recipe_submissions_lambda" {
+  type        = "zip"
+  source_file = "${path.module}/lambda/recipe-submissions/index.mjs"
+  output_path = "${path.module}/.terraform/recipe-submissions-lambda.zip"
+}
+
+resource "aws_lambda_function" "recipe_submissions" {
+  function_name    = var.recipe_submissions_lambda_function_name
+  description      = "Handles Drake's Food recipe idea submissions."
+  filename         = data.archive_file.recipe_submissions_lambda.output_path
+  source_code_hash = data.archive_file.recipe_submissions_lambda.output_base64sha256
+  handler          = "index.handler"
+  runtime          = "nodejs22.x"
+  role             = aws_iam_role.recipe_submissions_lambda.arn
+  timeout          = 10
+  memory_size      = 128
+
+  environment {
+    variables = {
+      ALLOWED_ORIGINS                = join(",", var.recipe_submissions_allowed_origins)
+      RECIPE_SUBMISSIONS_TABLE_NAME  = aws_dynamodb_table.recipe_submissions.name
+      RECIPE_SUBMISSIONS_SOURCE_SITE = var.recipe_submissions_source_site
+      SES_RECIPIENT_EMAIL            = var.recipe_submissions_ses_recipient_email
+      SES_SENDER_EMAIL               = var.recipe_submissions_ses_sender_email
+    }
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.recipe_submissions_lambda,
+    aws_iam_role_policy.recipe_submissions_lambda,
+  ]
+}
+
+resource "aws_apigatewayv2_api" "recipe_submissions" {
+  name          = var.recipe_submissions_api_name
+  protocol_type = "HTTP"
+
+  cors_configuration {
+    allow_headers = ["content-type"]
+    allow_methods = ["POST", "OPTIONS"]
+    allow_origins = var.recipe_submissions_allowed_origins
+    max_age       = 3600
+  }
+}
+
+resource "aws_apigatewayv2_integration" "recipe_submissions" {
+  api_id                 = aws_apigatewayv2_api.recipe_submissions.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.recipe_submissions.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "recipe_submissions_post" {
+  api_id    = aws_apigatewayv2_api.recipe_submissions.id
+  route_key = "POST /recipe-submissions"
+  target    = "integrations/${aws_apigatewayv2_integration.recipe_submissions.id}"
+}
+
+resource "aws_apigatewayv2_stage" "recipe_submissions_default" {
+  api_id      = aws_apigatewayv2_api.recipe_submissions.id
+  name        = "$default"
+  auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.recipe_submissions_api.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      httpMethod     = "$context.httpMethod"
+      routeKey       = "$context.routeKey"
+      status         = "$context.status"
+      responseLength = "$context.responseLength"
+    })
+  }
+
+  default_route_settings {
+    throttling_burst_limit = var.recipe_submissions_throttling_burst_limit
+    throttling_rate_limit  = var.recipe_submissions_throttling_rate_limit
+  }
+}
+
+resource "aws_lambda_permission" "recipe_submissions_api" {
+  statement_id  = "AllowRecipeSubmissionsApiInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.recipe_submissions.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.recipe_submissions.execution_arn}/*/*"
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -27,3 +27,73 @@ variable "github_actions_deploy_user_name" {
   type        = string
   default     = "github-actions-drakesfood-deploy"
 }
+
+variable "recipe_submissions_api_name" {
+  description = "API Gateway HTTP API name for recipe submissions."
+  type        = string
+  default     = "drakesfood-recipe-submissions"
+}
+
+variable "recipe_submissions_allowed_origins" {
+  description = "Browser origins allowed to call the recipe submission API."
+  type        = list(string)
+  default = [
+    "https://drakesfood.com",
+    "https://www.drakesfood.com",
+    "http://localhost:4200",
+  ]
+}
+
+variable "recipe_submissions_lambda_function_name" {
+  description = "Lambda function name for recipe submissions."
+  type        = string
+  default     = "drakesfood-recipe-submissions"
+}
+
+variable "recipe_submissions_log_retention_days" {
+  description = "CloudWatch log retention in days for recipe submission resources."
+  type        = number
+  default     = 30
+}
+
+variable "recipe_submissions_ses_identity_arn" {
+  description = "Optional SES identity ARN allowed to send recipe submission emails. Defaults to the domain identity for the active AWS account."
+  type        = string
+  default     = ""
+}
+
+variable "recipe_submissions_ses_recipient_email" {
+  description = "Email address that receives recipe submission notifications. Set with a tfvars file or CLI variable."
+  type        = string
+  default     = ""
+}
+
+variable "recipe_submissions_ses_sender_email" {
+  description = "Verified SES sender email address for recipe submission notifications. Set with a tfvars file or CLI variable."
+  type        = string
+  default     = ""
+}
+
+variable "recipe_submissions_source_site" {
+  description = "Source site value stored with accepted recipe submissions."
+  type        = string
+  default     = "drakesfood.com"
+}
+
+variable "recipe_submissions_table_name" {
+  description = "DynamoDB table name for recipe submissions."
+  type        = string
+  default     = "drakesfood-recipe-submissions"
+}
+
+variable "recipe_submissions_throttling_burst_limit" {
+  description = "API Gateway burst throttling limit for recipe submissions."
+  type        = number
+  default     = 10
+}
+
+variable "recipe_submissions_throttling_rate_limit" {
+  description = "API Gateway steady-state requests per second limit for recipe submissions."
+  type        = number
+  default     = 5
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -6,6 +6,11 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add OpenTofu infrastructure for the V1 recipe submission backend: HTTP API, Lambda, DynamoDB, CloudWatch logs, Lambda invoke permission, and least-privilege Lambda IAM policy.
- Add restricted CORS defaults for `drakesfood.com`, `www.drakesfood.com`, and local Angular development.
- Include a placeholder Lambda source package so infrastructure can validate before issue #27 adds real handler logic.
- Document required SES sender/recipient setup and expose outputs for frontend wiring.

Closes #26

## Validation
- `tofu init` passed.
- `tofu fmt -check -recursive` passed.
- `tofu validate` passed.
- `AWS_PROFILE=drakesfood tofu plan -input=false` passed: 11 to add, 0 to change, 0 to destroy.
- `npm run typecheck` passed.
- `npm run build` passed.
- `npm run lint` passed.

Note: local Node emitted a warning because the active shell is using `v25.9.0`; the repo expects Node 22 LTS. Validation still completed successfully.

## Visual Review
- Not applicable; infrastructure-only change.

## Known Notes
- This does not apply infrastructure. Drake should review and apply manually after merge.
- The Lambda handler intentionally returns a placeholder `501` response until issue #27 implements real submission handling.
- SES sender and recipient values must be configured locally or in deployment variables before production email notifications can work.