### PR TITLE
Implement recipe submission Lambda handler

### DIFF
--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -37,10 +37,11 @@
 - [x] App builds successfully
 - [x] TypeScript type checking passes
 - [x] Recipe submission API contract documented
+- [x] Recipe submission AWS infrastructure defined
 
 ## 🔄 In Progress
 
-- [ ] Add recipe submission AWS infrastructure — #26
+- [ ] Implement recipe submission Lambda handler — #27
 - [ ] Conduct performance and accessibility review — #17
 
 ## 📋 Remaining Tasks
@@ -54,7 +55,7 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - [ ] Add RecipeSensei launch details once available — #21
 - [ ] Refine About section content — #16
 - [ ] Add optional recipe/blog details page later — #22
-- [ ] Add recipe submission Lambda, API wiring, security, email, and docs — #27-#31
+- [ ] Add recipe submission API wiring, security, email, and docs — #28-#31
 
 ### Deployment & Infrastructure
 
@@ -97,7 +98,8 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - Instagram link remains `https://instagram.com/drakesfood`
 - Recipe submissions are starting with a frontend-only form section; live API wiring remains a follow-up.
 - Recipe submission API contract is documented before backend and infrastructure implementation.
-- Recipe submission infrastructure is being added with OpenTofu using API Gateway, Lambda, DynamoDB, SES permissions, and CloudWatch logs.
+- Recipe submission infrastructure is defined with OpenTofu using API Gateway, Lambda, DynamoDB, SES permissions, and CloudWatch logs.
+- Recipe submission Lambda handler is being implemented with server-side validation, honeypot handling, and DynamoDB writes.
 - Generic `/favicon.ico` and `/favicon.png` fallbacks should match the named chef-ninja favicon files for browsers that request default favicon paths directly.
 - Purple theme accents now use shared CSS variables, with a ninja chef mascot in the hero and SVG favicon support
 - Ninja chef mascot now uses a transparent PNG generated with ChatGPT, resized to 128px for the hero and 192px for the favicon

--- a/infra/lambda/recipe-submissions/index.mjs
+++ b/infra/lambda/recipe-submissions/index.mjs
@@ -1,10 +1,259 @@
-export const handler = async () => ({
-  statusCode: 501,
-  headers: {
-    'content-type': 'application/json',
-  },
-  body: JSON.stringify({
-    success: false,
-    message: 'Recipe submissions are not connected yet.',
-  }),
-});
+import { randomUUID } from 'node:crypto';
+
+const SUCCESS_MESSAGE = 'Thanks! Your idea was sent to Drake.';
+const VALIDATION_MESSAGE = 'Please include a recipe title and description.';
+
+const FIELD_LIMITS = {
+  title: 120,
+  description: 3000,
+  name: 100,
+  email: 254,
+  recipeUrl: 500,
+  socialUrl: 500,
+};
+
+const STRING_FIELDS = ['title', 'description', 'name', 'email', 'recipeUrl', 'socialUrl', 'website'];
+
+let dynamoClient;
+let putItemCommand;
+
+export const createHandler = ({
+  now = () => new Date(),
+  saveSubmission = saveSubmissionToDynamoDb,
+  uuid = randomUUID,
+} = {}) => async (event = {}) => {
+  if (getMethod(event) !== 'POST') {
+    return jsonResponse(405, {
+      success: false,
+      message: 'Recipe submissions only accept POST requests.',
+    });
+  }
+
+  let body;
+
+  try {
+    body = parseBody(event);
+  } catch {
+    return jsonResponse(400, {
+      success: false,
+      message: 'Please send a valid JSON recipe submission.',
+    });
+  }
+
+  const normalized = normalizeBody(body);
+
+  if (!normalized.valid) {
+    return jsonResponse(400, {
+      success: false,
+      message: VALIDATION_MESSAGE,
+    });
+  }
+
+  if (normalized.values.website) {
+    console.info('Recipe submission ignored by spam filter.');
+
+    return jsonResponse(200, {
+      success: true,
+      message: SUCCESS_MESSAGE,
+    });
+  }
+
+  const validationError = validateSubmission(normalized.values);
+
+  if (validationError) {
+    return jsonResponse(400, {
+      success: false,
+      message: validationError,
+    });
+  }
+
+  const item = buildSubmissionItem(normalized.values, now().toISOString(), uuid());
+
+  try {
+    await saveSubmission(item);
+  } catch (error) {
+    console.error('Failed to save recipe submission.', {
+      errorName: error?.name,
+      submissionId: item.submissionId,
+    });
+
+    return jsonResponse(500, {
+      success: false,
+      message: 'Something went wrong sending your recipe idea. Please try again later.',
+    });
+  }
+
+  return jsonResponse(200, {
+    success: true,
+    message: SUCCESS_MESSAGE,
+  });
+};
+
+export const handler = createHandler();
+
+function getMethod(event) {
+  return event.requestContext?.http?.method ?? event.httpMethod ?? '';
+}
+
+function parseBody(event) {
+  const rawBody = event.isBase64Encoded ? Buffer.from(event.body ?? '', 'base64').toString('utf8') : event.body;
+
+  if (!rawBody) {
+    throw new Error('Missing body');
+  }
+
+  const parsed = JSON.parse(rawBody);
+
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+    throw new Error('Invalid body');
+  }
+
+  return parsed;
+}
+
+function normalizeBody(body) {
+  const values = {
+    title: '',
+    description: '',
+    name: '',
+    email: '',
+    recipeUrl: '',
+    socialUrl: '',
+    permissionToCredit: false,
+    website: '',
+  };
+
+  for (const field of STRING_FIELDS) {
+    if (body[field] === undefined || body[field] === null) {
+      continue;
+    }
+
+    if (typeof body[field] !== 'string') {
+      return { valid: false, values };
+    }
+
+    values[field] = body[field].trim();
+  }
+
+  if (body.permissionToCredit !== undefined && typeof body.permissionToCredit !== 'boolean') {
+    return { valid: false, values };
+  }
+
+  values.permissionToCredit = body.permissionToCredit === true;
+
+  return { valid: true, values };
+}
+
+function validateSubmission(values) {
+  if (!values.title || !values.description) {
+    return VALIDATION_MESSAGE;
+  }
+
+  for (const [field, limit] of Object.entries(FIELD_LIMITS)) {
+    if (values[field].length > limit) {
+      return `Please keep ${field} under ${limit} characters.`;
+    }
+  }
+
+  if (values.email && !isValidEmail(values.email)) {
+    return 'Please enter a valid email address or leave it blank.';
+  }
+
+  if (values.recipeUrl && !isValidHttpUrl(values.recipeUrl)) {
+    return 'Please enter a valid recipe URL or leave it blank.';
+  }
+
+  if (values.socialUrl && !isValidHttpUrl(values.socialUrl)) {
+    return 'Please enter a valid social URL or leave it blank.';
+  }
+
+  return '';
+}
+
+function buildSubmissionItem(values, submittedAt, submissionId) {
+  const item = {
+    submissionId,
+    submittedAt,
+    status: 'new',
+    title: values.title,
+    description: values.description,
+    permissionToCredit: values.permissionToCredit,
+    source: process.env.RECIPE_SUBMISSIONS_SOURCE_SITE || 'drakesfood.com',
+  };
+
+  for (const field of ['name', 'email', 'recipeUrl', 'socialUrl']) {
+    if (values[field]) {
+      item[field] = values[field];
+    }
+  }
+
+  return item;
+}
+
+async function saveSubmissionToDynamoDb(item) {
+  const tableName = process.env.RECIPE_SUBMISSIONS_TABLE_NAME;
+
+  if (!tableName) {
+    throw new Error('Missing RECIPE_SUBMISSIONS_TABLE_NAME');
+  }
+
+  const { DynamoDBClient, PutItemCommand } = await loadDynamoDbClient();
+  const client = dynamoClient ?? new DynamoDBClient({});
+  dynamoClient = client;
+
+  await client.send(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: toDynamoDbItem(item),
+      ConditionExpression: 'attribute_not_exists(submissionId)',
+    }),
+  );
+}
+
+async function loadDynamoDbClient() {
+  if (putItemCommand) {
+    return putItemCommand;
+  }
+
+  putItemCommand = await import('@aws-sdk/client-dynamodb');
+
+  return putItemCommand;
+}
+
+function toDynamoDbItem(item) {
+  const dynamoItem = {};
+
+  for (const [key, value] of Object.entries(item)) {
+    if (typeof value === 'boolean') {
+      dynamoItem[key] = { BOOL: value };
+    } else {
+      dynamoItem[key] = { S: value };
+    }
+  }
+
+  return dynamoItem;
+}
+
+function isValidEmail(value) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function isValidHttpUrl(value) {
+  try {
+    const url = new URL(value);
+
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function jsonResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  };
+}

--- a/infra/lambda/recipe-submissions/index.test.mjs
+++ b/infra/lambda/recipe-submissions/index.test.mjs
@@ -1,0 +1,172 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHandler } from './index.mjs';
+
+const fixedDate = new Date('2026-04-30T14:30:00.000Z');
+
+function createEvent(body, method = 'POST') {
+  return {
+    requestContext: {
+      http: {
+        method,
+      },
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+function parseResponse(response) {
+  return JSON.parse(response.body);
+}
+
+test('saves a valid recipe submission', async () => {
+  const savedItems = [];
+  const handler = createHandler({
+    now: () => fixedDate,
+    uuid: () => 'submission-123',
+    saveSubmission: async (item) => savedItems.push(item),
+  });
+
+  const response = await handler(
+    createEvent({
+      title: '  Smoked birria tacos  ',
+      description: 'Cook these on the smoker.',
+      name: 'Drake Fan',
+      email: 'fan@example.com',
+      recipeUrl: 'https://example.com/recipe',
+      socialUrl: 'https://instagram.com/example',
+      permissionToCredit: true,
+      website: '',
+    }),
+  );
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(parseResponse(response), {
+    success: true,
+    message: 'Thanks! Your idea was sent to Drake.',
+  });
+  assert.deepEqual(savedItems, [
+    {
+      submissionId: 'submission-123',
+      submittedAt: '2026-04-30T14:30:00.000Z',
+      status: 'new',
+      title: 'Smoked birria tacos',
+      description: 'Cook these on the smoker.',
+      name: 'Drake Fan',
+      email: 'fan@example.com',
+      recipeUrl: 'https://example.com/recipe',
+      socialUrl: 'https://instagram.com/example',
+      permissionToCredit: true,
+      source: 'drakesfood.com',
+    },
+  ]);
+});
+
+test('returns validation error without saving when required fields are missing', async () => {
+  const savedItems = [];
+  const handler = createHandler({ saveSubmission: async (item) => savedItems.push(item) });
+
+  const response = await handler(createEvent({ title: '', description: '' }));
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Please include a recipe title and description.',
+  });
+  assert.deepEqual(savedItems, []);
+});
+
+test('handles populated honeypot as generic success without saving', async () => {
+  const savedItems = [];
+  const handler = createHandler({ saveSubmission: async (item) => savedItems.push(item) });
+
+  const response = await handler(
+    createEvent({
+      title: 'Spam title',
+      description: 'Spam description',
+      website: 'https://bot.example',
+    }),
+  );
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(parseResponse(response), {
+    success: true,
+    message: 'Thanks! Your idea was sent to Drake.',
+  });
+  assert.deepEqual(savedItems, []);
+});
+
+test('rejects malformed JSON cleanly', async () => {
+  const handler = createHandler({ saveSubmission: async () => undefined });
+
+  const response = await handler({
+    requestContext: { http: { method: 'POST' } },
+    body: '{nope',
+  });
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Please send a valid JSON recipe submission.',
+  });
+});
+
+test('rejects non-POST requests cleanly', async () => {
+  const handler = createHandler({ saveSubmission: async () => undefined });
+
+  const response = await handler(createEvent({}, 'GET'));
+
+  assert.equal(response.statusCode, 405);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Recipe submissions only accept POST requests.',
+  });
+});
+
+test('rejects invalid optional email and URL values', async () => {
+  const handler = createHandler({ saveSubmission: async () => undefined });
+
+  const invalidEmailResponse = await handler(
+    createEvent({
+      title: 'Pizza',
+      description: 'Try it outside.',
+      email: 'not-an-email',
+    }),
+  );
+  const invalidUrlResponse = await handler(
+    createEvent({
+      title: 'Pizza',
+      description: 'Try it outside.',
+      recipeUrl: 'notaurl',
+    }),
+  );
+
+  assert.equal(invalidEmailResponse.statusCode, 400);
+  assert.equal(parseResponse(invalidEmailResponse).message, 'Please enter a valid email address or leave it blank.');
+  assert.equal(invalidUrlResponse.statusCode, 400);
+  assert.equal(parseResponse(invalidUrlResponse).message, 'Please enter a valid recipe URL or leave it blank.');
+});
+
+test('parses base64-encoded request bodies', async () => {
+  const savedItems = [];
+  const handler = createHandler({
+    now: () => fixedDate,
+    uuid: () => 'submission-456',
+    saveSubmission: async (item) => savedItems.push(item),
+  });
+  const encodedBody = Buffer.from(
+    JSON.stringify({
+      title: 'Pizza',
+      description: 'Try this in the Ooni.',
+    }),
+  ).toString('base64');
+
+  const response = await handler({
+    requestContext: { http: { method: 'POST' } },
+    isBase64Encoded: true,
+    body: encodedBody,
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(savedItems[0].submissionId, 'submission-456');
+});


### PR DESCRIPTION
## Summary
- Replace the placeholder recipe submission Lambda with real request parsing, validation, honeypot handling, metadata generation, and DynamoDB writes.
- Add friendly JSON responses for malformed JSON, validation failures, unsupported methods, save failures, and success.
- Add handler-level Node tests with an injected save function so validation and storage behavior can be checked without AWS calls.

Closes #27

## Validation
- `node --test infra/lambda/recipe-submissions/index.test.mjs` passed.
- `tofu fmt -check -recursive` passed.
- `tofu validate` passed.
- `AWS_PROFILE=drakesfood tofu plan -input=false` passed: 11 to add, 0 to change, 0 to destroy.
- `npm run typecheck` passed.
- `npm run build` passed.
- `npm run lint` passed.
- `git diff --check` passed.

Note: local Node emitted a warning because the active shell is using `v25.9.0`; the repo expects Node 22 LTS. Validation still completed successfully.

## Visual Review
- Not applicable; backend Lambda change only.

## Known Notes
- No infrastructure was applied.
- SES email notification remains out of scope for this issue and is tracked by #28.
- Frontend API wiring remains out of scope and is tracked by #29.