### PR TITLE
Add recipe submission email notifications

### DIFF
--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -38,10 +38,11 @@
 - [x] TypeScript type checking passes
 - [x] Recipe submission API contract documented
 - [x] Recipe submission AWS infrastructure defined
+- [x] Recipe submission Lambda handler implemented
 
 ## 🔄 In Progress
 
-- [ ] Implement recipe submission Lambda handler — #27
+- [ ] Add recipe submission email notifications — #28
 - [ ] Conduct performance and accessibility review — #17
 
 ## 📋 Remaining Tasks
@@ -55,7 +56,7 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - [ ] Add RecipeSensei launch details once available — #21
 - [ ] Refine About section content — #16
 - [ ] Add optional recipe/blog details page later — #22
-- [ ] Add recipe submission API wiring, security, email, and docs — #28-#31
+- [ ] Add recipe submission API wiring, security, and docs — #29-#31
 
 ### Deployment & Infrastructure
 
@@ -99,7 +100,8 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - Recipe submissions are starting with a frontend-only form section; live API wiring remains a follow-up.
 - Recipe submission API contract is documented before backend and infrastructure implementation.
 - Recipe submission infrastructure is defined with OpenTofu using API Gateway, Lambda, DynamoDB, SES permissions, and CloudWatch logs.
-- Recipe submission Lambda handler is being implemented with server-side validation, honeypot handling, and DynamoDB writes.
+- Recipe submission Lambda handler validates server-side input, handles honeypot submissions, and writes accepted ideas to DynamoDB.
+- Recipe submission email notifications are being added through SES after accepted submissions are stored.
 - Generic `/favicon.ico` and `/favicon.png` fallbacks should match the named chef-ninja favicon files for browsers that request default favicon paths directly.
 - Purple theme accents now use shared CSS variables, with a ninja chef mascot in the hero and SVG favicon support
 - Ninja chef mascot now uses a transparent PNG generated with ChatGPT, resized to 128px for the hero and 192px for the favicon

--- a/infra/README.md
+++ b/infra/README.md
@@ -25,9 +25,10 @@ The recipe submission backend is defined as low-cost serverless infrastructure:
 - CORS is restricted to `drakesfood.com`, `www.drakesfood.com`, and local Angular development by default.
 - Lambda receives the table name, source site, allowed origins, and SES sender/recipient values through environment variables.
 - DynamoDB stores accepted submissions by `submissionId`.
+- SES sends Drake a plain-text notification after valid submissions are stored.
 - CloudWatch log groups use the configured retention period.
 
-Issue #26 only defines the infrastructure. The Lambda source at `lambda/recipe-submissions/index.mjs` is a placeholder so OpenTofu can package and validate the function before issue #27 adds real submission handling.
+The Lambda source lives at `lambda/recipe-submissions/index.mjs`. It validates submissions, stores accepted ideas in DynamoDB, and sends SES notifications when sender and recipient values are configured.
 
 Before applying recipe submission infrastructure for production, set these values with a local `.tfvars` file or `-var` arguments. The SES identity ARN can be omitted if the verified identity is the site domain in the active AWS account.
 
@@ -37,7 +38,7 @@ recipe_submissions_ses_sender_email    = "<verified-sender-email>"
 recipe_submissions_ses_recipient_email = "<recipient-email>"
 ```
 
-Do not commit real email addresses or account-specific values unless they are intentionally public. The SES sender identity must be verified before email notifications can work.
+Do not commit real email addresses or account-specific values unless they are intentionally public. The SES sender identity must be verified before email notifications can work. If the SES sender or recipient is missing, accepted submissions are still stored but email notification is skipped and logged. If SES fails after storage, the Lambda logs the failure and still returns success to avoid encouraging duplicate submissions.
 
 After apply, get the API endpoint for frontend configuration:
 

--- a/infra/lambda/recipe-submissions/index.mjs
+++ b/infra/lambda/recipe-submissions/index.mjs
@@ -16,10 +16,13 @@ const STRING_FIELDS = ['title', 'description', 'name', 'email', 'recipeUrl', 'so
 
 let dynamoClient;
 let putItemCommand;
+let sesClient;
+let sendEmailCommand;
 
 export const createHandler = ({
   now = () => new Date(),
   saveSubmission = saveSubmissionToDynamoDb,
+  sendNotification = sendNotificationEmail,
   uuid = randomUUID,
 } = {}) => async (event = {}) => {
   if (getMethod(event) !== 'POST') {
@@ -80,6 +83,15 @@ export const createHandler = ({
     return jsonResponse(500, {
       success: false,
       message: 'Something went wrong sending your recipe idea. Please try again later.',
+    });
+  }
+
+  try {
+    await sendNotification(item);
+  } catch (error) {
+    console.error('Failed to send recipe submission notification.', {
+      errorName: error?.name,
+      submissionId: item.submissionId,
     });
   }
 
@@ -210,6 +222,43 @@ async function saveSubmissionToDynamoDb(item) {
   );
 }
 
+async function sendNotificationEmail(item) {
+  const senderEmail = process.env.SES_SENDER_EMAIL;
+  const recipientEmail = process.env.SES_RECIPIENT_EMAIL;
+
+  if (!senderEmail || !recipientEmail) {
+    console.warn('Recipe submission notification skipped because SES sender or recipient is not configured.', {
+      submissionId: item.submissionId,
+    });
+    return;
+  }
+
+  const { SESClient, SendEmailCommand } = await loadSesClient();
+  const client = sesClient ?? new SESClient({});
+  sesClient = client;
+
+  await client.send(
+    new SendEmailCommand({
+      Source: senderEmail,
+      Destination: {
+        ToAddresses: [recipientEmail],
+      },
+      Message: {
+        Subject: {
+          Charset: 'UTF-8',
+          Data: `New recipe idea: ${item.title}`,
+        },
+        Body: {
+          Text: {
+            Charset: 'UTF-8',
+            Data: formatNotificationEmail(item),
+          },
+        },
+      },
+    }),
+  );
+}
+
 async function loadDynamoDbClient() {
   if (putItemCommand) {
     return putItemCommand;
@@ -218,6 +267,34 @@ async function loadDynamoDbClient() {
   putItemCommand = await import('@aws-sdk/client-dynamodb');
 
   return putItemCommand;
+}
+
+async function loadSesClient() {
+  if (sendEmailCommand) {
+    return sendEmailCommand;
+  }
+
+  sendEmailCommand = await import('@aws-sdk/client-ses');
+
+  return sendEmailCommand;
+}
+
+function formatNotificationEmail(item) {
+  return [
+    'A new recipe idea was submitted on drakesfood.com.',
+    '',
+    `Title: ${item.title}`,
+    `Description / notes: ${item.description}`,
+    `Name or handle: ${item.name || 'Not provided'}`,
+    `Email: ${item.email || 'Not provided'}`,
+    `Recipe URL: ${item.recipeUrl || 'Not provided'}`,
+    `Social URL: ${item.socialUrl || 'Not provided'}`,
+    `Permission to credit: ${item.permissionToCredit ? 'Yes' : 'No'}`,
+    '',
+    `Submission ID: ${item.submissionId}`,
+    `Submitted at: ${item.submittedAt}`,
+    `Source: ${item.source}`,
+  ].join('\n');
 }
 
 function toDynamoDbItem(item) {

--- a/infra/lambda/recipe-submissions/index.test.mjs
+++ b/infra/lambda/recipe-submissions/index.test.mjs
@@ -21,10 +21,12 @@ function parseResponse(response) {
 
 test('saves a valid recipe submission', async () => {
   const savedItems = [];
+  const notifications = [];
   const handler = createHandler({
     now: () => fixedDate,
     uuid: () => 'submission-123',
     saveSubmission: async (item) => savedItems.push(item),
+    sendNotification: async (item) => notifications.push(item),
   });
 
   const response = await handler(
@@ -60,11 +62,16 @@ test('saves a valid recipe submission', async () => {
       source: 'drakesfood.com',
     },
   ]);
+  assert.deepEqual(notifications, savedItems);
 });
 
 test('returns validation error without saving when required fields are missing', async () => {
   const savedItems = [];
-  const handler = createHandler({ saveSubmission: async (item) => savedItems.push(item) });
+  const notifications = [];
+  const handler = createHandler({
+    saveSubmission: async (item) => savedItems.push(item),
+    sendNotification: async (item) => notifications.push(item),
+  });
 
   const response = await handler(createEvent({ title: '', description: '' }));
 
@@ -74,11 +81,16 @@ test('returns validation error without saving when required fields are missing',
     message: 'Please include a recipe title and description.',
   });
   assert.deepEqual(savedItems, []);
+  assert.deepEqual(notifications, []);
 });
 
 test('handles populated honeypot as generic success without saving', async () => {
   const savedItems = [];
-  const handler = createHandler({ saveSubmission: async (item) => savedItems.push(item) });
+  const notifications = [];
+  const handler = createHandler({
+    saveSubmission: async (item) => savedItems.push(item),
+    sendNotification: async (item) => notifications.push(item),
+  });
 
   const response = await handler(
     createEvent({
@@ -94,6 +106,7 @@ test('handles populated honeypot as generic success without saving', async () =>
     message: 'Thanks! Your idea was sent to Drake.',
   });
   assert.deepEqual(savedItems, []);
+  assert.deepEqual(notifications, []);
 });
 
 test('rejects malformed JSON cleanly', async () => {
@@ -169,4 +182,30 @@ test('parses base64-encoded request bodies', async () => {
 
   assert.equal(response.statusCode, 200);
   assert.equal(savedItems[0].submissionId, 'submission-456');
+});
+
+test('returns success when notification fails after saving', async () => {
+  const savedItems = [];
+  const handler = createHandler({
+    now: () => fixedDate,
+    uuid: () => 'submission-789',
+    saveSubmission: async (item) => savedItems.push(item),
+    sendNotification: async () => {
+      throw new Error('SES unavailable');
+    },
+  });
+
+  const response = await handler(
+    createEvent({
+      title: 'Ratatouille',
+      description: 'Try a smoky version.',
+    }),
+  );
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(parseResponse(response), {
+    success: true,
+    message: 'Thanks! Your idea was sent to Drake.',
+  });
+  assert.equal(savedItems.length, 1);
 });


### PR DESCRIPTION
## Summary
- Send SES plain-text notifications after valid recipe submissions are saved to DynamoDB.
- Include submission details and metadata in the email body.
- Skip notifications for invalid or honeypot submissions, and log SES failures without failing already-stored submissions.
- Document SES notification behavior and required sender/recipient configuration.

Closes #28

## Validation
- `node --test infra/lambda/recipe-submissions/index.test.mjs` passed.
- `tofu fmt -check -recursive` passed.
- `tofu validate` passed.
- `AWS_PROFILE=drakesfood tofu plan -input=false` passed: 11 to add, 0 to change, 0 to destroy.
- `npm run typecheck` passed.
- `npm run build` passed.
- `npm run lint` passed.
- `git diff --check` passed.

Note: local Node emitted a warning because the active shell is using `v25.9.0`; the repo expects Node 22 LTS. Validation still completed successfully.

## Visual Review
- Not applicable; backend Lambda change only.

## Known Notes
- No infrastructure was applied.
- SES sender and recipient values must be configured before production notifications work.
- Frontend API wiring remains out of scope and is tracked by #29.