### PR TITLE
Wire recipe form to submission API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ env:
   AWS_REGION: us-east-2
   S3_BUCKET: drakesfood.com
   CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
+  RECIPE_SUBMISSIONS_API_BASE_URL: ${{ vars.RECIPE_SUBMISSIONS_API_BASE_URL }}
 
 jobs:
   deploy:
@@ -39,6 +40,10 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Write runtime app config
+        run: |
+          node -e 'const fs = require("node:fs"); const config = { recipeSubmissionsApiBaseUrl: process.env.RECIPE_SUBMISSIONS_API_BASE_URL || "" }; fs.writeFileSync("dist/drakesfood-app/browser/app-config.json", JSON.stringify(config, null, 2) + "\n");'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -39,10 +39,11 @@
 - [x] Recipe submission API contract documented
 - [x] Recipe submission AWS infrastructure defined
 - [x] Recipe submission Lambda handler implemented
+- [x] Recipe submission email notifications added
 
 ## 🔄 In Progress
 
-- [ ] Add recipe submission email notifications — #28
+- [ ] Wire recipe submission form to live API — #29
 - [ ] Conduct performance and accessibility review — #17
 
 ## 📋 Remaining Tasks
@@ -56,7 +57,7 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - [ ] Add RecipeSensei launch details once available — #21
 - [ ] Refine About section content — #16
 - [ ] Add optional recipe/blog details page later — #22
-- [ ] Add recipe submission API wiring, security, and docs — #29-#31
+- [ ] Add recipe submission security hardening and docs — #30-#31
 
 ### Deployment & Infrastructure
 
@@ -97,11 +98,12 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - Angular test runner setup remains deferred and tracked separately
 - RecipeSensei remains marked as "coming soon" until launch
 - Instagram link remains `https://instagram.com/drakesfood`
-- Recipe submissions are starting with a frontend-only form section; live API wiring remains a follow-up.
+- Recipe submissions started with a frontend-only form section; live API wiring is now in progress.
 - Recipe submission API contract is documented before backend and infrastructure implementation.
 - Recipe submission infrastructure is defined with OpenTofu using API Gateway, Lambda, DynamoDB, SES permissions, and CloudWatch logs.
 - Recipe submission Lambda handler validates server-side input, handles honeypot submissions, and writes accepted ideas to DynamoDB.
-- Recipe submission email notifications are being added through SES after accepted submissions are stored.
+- Recipe submission email notifications are sent through SES after accepted submissions are stored.
+- Recipe submission frontend wiring uses runtime app config so the API endpoint can be set after OpenTofu apply.
 - Generic `/favicon.ico` and `/favicon.png` fallbacks should match the named chef-ninja favicon files for browsers that request default favicon paths directly.
 - Purple theme accents now use shared CSS variables, with a ninja chef mascot in the hero and SVG favicon support
 - Ninja chef mascot now uses a transparent PNG generated with ChatGPT, resized to 128px for the hero and 192px for the favicon

--- a/infra/README.md
+++ b/infra/README.md
@@ -97,10 +97,11 @@ AWS_PROFILE=drakesfood tofu plan
 AWS_PROFILE=drakesfood tofu apply
 ```
 
-After apply finishes, get the CloudFront distribution ID:
+After apply finishes, get the CloudFront distribution ID and recipe submission API endpoint:
 
 ```bash
 AWS_PROFILE=drakesfood tofu output -raw cloudfront_distribution_id
+AWS_PROFILE=drakesfood tofu output -raw recipe_submissions_api_endpoint
 ```
 
 Add that value as a GitHub repository variable named `CLOUDFRONT_DISTRIBUTION_ID`.
@@ -112,9 +113,12 @@ The deploy workflow needs these GitHub repository secrets:
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 
-It also needs this GitHub repository variable:
+It also needs these GitHub repository variables:
 
 - `CLOUDFRONT_DISTRIBUTION_ID`
+- `RECIPE_SUBMISSIONS_API_BASE_URL`
+
+Set `RECIPE_SUBMISSIONS_API_BASE_URL` to the `recipe_submissions_api_endpoint` OpenTofu output after the recipe submission infrastructure is applied. The deploy workflow writes this value into `app-config.json` at deploy time. Until it is configured, the public form keeps its not-connected-yet fallback.
 
 The AWS credentials must be allowed to sync files to the S3 bucket and create CloudFront invalidations. Until `CLOUDFRONT_DISTRIBUTION_ID` is configured, the deploy workflow will still sync to S3 but will skip CloudFront invalidation.
 

--- a/public/app-config.json
+++ b/public/app-config.json
@@ -1,0 +1,3 @@
+{
+  "recipeSubmissionsApiBaseUrl": ""
+}

--- a/src/app/components/recipe-submission/recipe-submission.component.html
+++ b/src/app/components/recipe-submission/recipe-submission.component.html
@@ -86,12 +86,12 @@
     <div class="form-actions">
       <button class="button button-primary" type="submit" [disabled]="isSubmitting()">
         @if (isSubmitting()) {
-          Checking idea...
+          Sending idea...
         } @else {
           Submit recipe idea
         }
       </button>
-      <p class="form-note">Live sending will be wired to <code>POST /recipe-submissions</code> in a follow-up.</p>
+      <p class="form-note">Submissions are text/link only and reviewed manually before anything is shared.</p>
     </div>
 
     @if (statusMessage()) {

--- a/src/app/components/recipe-submission/recipe-submission.component.ts
+++ b/src/app/components/recipe-submission/recipe-submission.component.ts
@@ -1,18 +1,8 @@
 import { Component, computed, inject, signal } from '@angular/core';
 import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RecipeSubmissionApiService, type RecipeSubmissionPayload } from '../../services/recipe-submission-api.service';
 
 type SubmissionStatus = 'idle' | 'submitting' | 'success' | 'error';
-
-interface RecipeSubmissionPayload {
-  title: string;
-  description: string;
-  name: string;
-  email: string;
-  recipeUrl: string;
-  socialUrl: string;
-  permissionToCredit: boolean;
-  website: string;
-}
 
 @Component({
   selector: 'app-recipe-submission',
@@ -23,7 +13,7 @@ interface RecipeSubmissionPayload {
 })
 export class RecipeSubmissionComponent {
   private readonly formBuilder = inject(NonNullableFormBuilder);
-  private simulatedRequest: ReturnType<typeof setTimeout> | undefined;
+  private readonly recipeSubmissionApi = inject(RecipeSubmissionApiService);
 
   readonly status = signal<SubmissionStatus>('idle');
   readonly statusMessage = signal('');
@@ -40,11 +30,7 @@ export class RecipeSubmissionComponent {
     website: [''],
   });
 
-  onSubmit(): void {
-    if (this.simulatedRequest) {
-      clearTimeout(this.simulatedRequest);
-    }
-
+  async onSubmit(): Promise<void> {
     const payload = this.buildPayload();
 
     // Keep honeypot handling generic so automated submissions do not get useful feedback.
@@ -62,15 +48,34 @@ export class RecipeSubmissionComponent {
     }
 
     this.status.set('submitting');
-    this.statusMessage.set('Checking the recipe idea...');
+    this.statusMessage.set('Sending your recipe idea...');
 
-    this.simulatedRequest = setTimeout(() => {
+    if (!(await this.recipeSubmissionApi.isConfigured())) {
       this.status.set('error');
       this.statusMessage.set(
         `This form is ready, but online recipe submissions are not connected yet. Your idea for "${payload.title}" has not been sent.`,
       );
-      this.simulatedRequest = undefined;
-    }, 400);
+      return;
+    }
+
+    try {
+      const message = await this.recipeSubmissionApi.submitRecipeIdea(payload);
+      this.submissionForm.reset({
+        title: '',
+        description: '',
+        name: '',
+        email: '',
+        recipeUrl: '',
+        socialUrl: '',
+        permissionToCredit: false,
+        website: '',
+      });
+      this.status.set('success');
+      this.statusMessage.set(message);
+    } catch (error) {
+      this.status.set('error');
+      this.statusMessage.set(error instanceof Error ? error.message : 'Recipe submissions are temporarily unavailable. Please try again later.');
+    }
   }
 
   hasFieldError(fieldName: keyof RecipeSubmissionPayload, errorName: string): boolean {

--- a/src/app/services/app-config.service.ts
+++ b/src/app/services/app-config.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+
+interface AppConfig {
+  recipeSubmissionsApiBaseUrl: string;
+}
+
+const defaultConfig: AppConfig = {
+  recipeSubmissionsApiBaseUrl: '',
+};
+
+@Injectable({ providedIn: 'root' })
+export class AppConfigService {
+  private configPromise: Promise<AppConfig> | undefined;
+
+  async getRecipeSubmissionsApiBaseUrl(): Promise<string> {
+    const config = await this.loadConfig();
+
+    return config.recipeSubmissionsApiBaseUrl;
+  }
+
+  private async loadConfig(): Promise<AppConfig> {
+    this.configPromise ??= this.fetchConfig();
+
+    return this.configPromise;
+  }
+
+  private async fetchConfig(): Promise<AppConfig> {
+    try {
+      const response = await fetch('/app-config.json', { cache: 'no-store' });
+
+      if (!response.ok) {
+        return defaultConfig;
+      }
+
+      const config = (await response.json()) as Partial<AppConfig>;
+      const recipeSubmissionsApiBaseUrl =
+        typeof config.recipeSubmissionsApiBaseUrl === 'string' ? config.recipeSubmissionsApiBaseUrl.trim().replace(/\/+$/, '') : '';
+
+      return {
+        recipeSubmissionsApiBaseUrl,
+      };
+    } catch {
+      return defaultConfig;
+    }
+  }
+}

--- a/src/app/services/recipe-submission-api.service.ts
+++ b/src/app/services/recipe-submission-api.service.ts
@@ -1,0 +1,73 @@
+import { inject, Injectable } from '@angular/core';
+import { AppConfigService } from './app-config.service';
+
+export interface RecipeSubmissionPayload {
+  title: string;
+  description: string;
+  name: string;
+  email: string;
+  recipeUrl: string;
+  socialUrl: string;
+  permissionToCredit: boolean;
+  website: string;
+}
+
+interface RecipeSubmissionApiResponse {
+  success: boolean;
+  message: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class RecipeSubmissionApiService {
+  private readonly appConfig = inject(AppConfigService);
+
+  async isConfigured(): Promise<boolean> {
+    return Boolean(await this.appConfig.getRecipeSubmissionsApiBaseUrl());
+  }
+
+  async submitRecipeIdea(payload: RecipeSubmissionPayload): Promise<string> {
+    const apiBaseUrl = await this.appConfig.getRecipeSubmissionsApiBaseUrl();
+
+    if (!apiBaseUrl) {
+      throw new Error('Recipe submission API is not configured.');
+    }
+
+    let response: Response;
+
+    try {
+      response = await fetch(`${apiBaseUrl}/recipe-submissions`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+    } catch {
+      throw new Error('Recipe submissions are temporarily unavailable. Please try again later.');
+    }
+
+    const body = await this.parseResponse(response);
+
+    if (!response.ok || !body.success) {
+      throw new Error(body.message || 'Recipe submissions are temporarily unavailable. Please try again later.');
+    }
+
+    return body.message;
+  }
+
+  private async parseResponse(response: Response): Promise<RecipeSubmissionApiResponse> {
+    try {
+      const body = (await response.json()) as Partial<RecipeSubmissionApiResponse>;
+
+      return {
+        success: body.success === true,
+        message: typeof body.message === 'string' ? body.message : '',
+      };
+    } catch {
+      return {
+        success: false,
+        message: 'Recipe submissions are temporarily unavailable. Please try again later.',
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add runtime `app-config.json` loading for the recipe submission API base URL.
- Replace the simulated form submit path with a real `POST /recipe-submissions` call when configured, while preserving the safe not-connected fallback locally.
- Keep honeypot handling generic, disable submit while sending, show API success/error messages, and clear the form only after success.
- Update deployment to write runtime config from `RECIPE_SUBMISSIONS_API_BASE_URL` and document the variable.

Closes #29

## Validation
- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run build` passed.
- Runtime config write command tested against `dist/drakesfood-app/browser/app-config.json`.
- `git diff --check` passed.

Note: local Node emitted a warning because the active shell is using `v25.9.0`; the repo expects Node 22 LTS. Validation still completed successfully.

## Visual Review
- Browser visual review was not run. UI-facing copy change is limited to the form note and submit loading text.

## Known Notes
- The public form will keep the not-connected fallback until `RECIPE_SUBMISSIONS_API_BASE_URL` is set from the OpenTofu API endpoint output.
- No infrastructure was applied in this PR.