### PR TITLE
Harden recipe submission security

### DIFF
--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -40,10 +40,11 @@
 - [x] Recipe submission AWS infrastructure defined
 - [x] Recipe submission Lambda handler implemented
 - [x] Recipe submission email notifications added
+- [x] Recipe submission frontend wired to runtime-configured API
 
 ## 🔄 In Progress
 
-- [ ] Wire recipe submission form to live API — #29
+- [ ] Add recipe submission security and spam hardening — #30
 - [ ] Conduct performance and accessibility review — #17
 
 ## 📋 Remaining Tasks
@@ -57,7 +58,7 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - [ ] Add RecipeSensei launch details once available — #21
 - [ ] Refine About section content — #16
 - [ ] Add optional recipe/blog details page later — #22
-- [ ] Add recipe submission security hardening and docs — #30-#31
+- [ ] Add recipe submission system documentation — #31
 
 ### Deployment & Infrastructure
 
@@ -104,6 +105,7 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - Recipe submission Lambda handler validates server-side input, handles honeypot submissions, and writes accepted ideas to DynamoDB.
 - Recipe submission email notifications are sent through SES after accepted submissions are stored.
 - Recipe submission frontend wiring uses runtime app config so the API endpoint can be set after OpenTofu apply.
+- Recipe submission security hardening is being added with Lambda origin checks, JSON content-type enforcement, request body size limits, CORS allowlists, throttling, and honeypot handling.
 - Generic `/favicon.ico` and `/favicon.png` fallbacks should match the named chef-ninja favicon files for browsers that request default favicon paths directly.
 - Purple theme accents now use shared CSS variables, with a ninja chef mascot in the hero and SVG favicon support
 - Ninja chef mascot now uses a transparent PNG generated with ChatGPT, resized to 128px for the hero and 192px for the favicon

--- a/docs/recipe-submission-api.md
+++ b/docs/recipe-submission-api.md
@@ -82,6 +82,17 @@ Use this response for missing required fields, empty required fields after trimm
 | `415 Unsupported Media Type` | Request does not use `application/json`, if content-type enforcement is implemented. |
 | `500 Internal Server Error` | Unexpected server failure. Return a generic message with no stack trace or AWS details. |
 
+## Security Behavior
+
+The API uses defense in depth for the public form:
+
+- API Gateway CORS is restricted to approved production and local development origins.
+- Lambda also checks the `Origin` header when present and rejects origins outside the configured allowlist.
+- Request bodies must use `application/json` when a `Content-Type` header is present.
+- Request bodies larger than the configured Lambda limit are rejected before JSON parsing.
+- API Gateway throttling is configured for a small V1 public form.
+- CAPTCHA is intentionally omitted for V1 unless real abuse requires it later.
+
 ## Honeypot Behavior
 
 `website` is a hidden spam-trap field. If `website` contains a non-empty value after trimming, the backend should:

--- a/infra/README.md
+++ b/infra/README.md
@@ -27,8 +27,11 @@ The recipe submission backend is defined as low-cost serverless infrastructure:
 - DynamoDB stores accepted submissions by `submissionId`.
 - SES sends Drake a plain-text notification after valid submissions are stored.
 - CloudWatch log groups use the configured retention period.
+- API Gateway throttling defaults to 10 burst requests and 5 sustained requests per second.
 
-The Lambda source lives at `lambda/recipe-submissions/index.mjs`. It validates submissions, stores accepted ideas in DynamoDB, and sends SES notifications when sender and recipient values are configured.
+The Lambda source lives at `lambda/recipe-submissions/index.mjs`. It validates submissions, stores accepted ideas in DynamoDB, and sends SES notifications when sender and recipient values are configured. It also enforces the configured origin allowlist for browser requests, requires JSON request bodies, rejects oversized request bodies, and handles honeypot submissions without revealing spam detection to bots.
+
+The Lambda request body limit defaults to `16384` bytes and can be adjusted with `recipe_submissions_max_body_bytes` if the text-only V1 form needs more room later. V1 intentionally does not include CAPTCHA; add it only if real abuse requires the extra friction.
 
 Before applying recipe submission infrastructure for production, set these values with a local `.tfvars` file or `-var` arguments. The SES identity ARN can be omitted if the verified identity is the site domain in the active AWS account.
 

--- a/infra/lambda/recipe-submissions/index.mjs
+++ b/infra/lambda/recipe-submissions/index.mjs
@@ -13,6 +13,7 @@ const FIELD_LIMITS = {
 };
 
 const STRING_FIELDS = ['title', 'description', 'name', 'email', 'recipeUrl', 'socialUrl', 'website'];
+const DEFAULT_MAX_BODY_BYTES = 16 * 1024;
 
 let dynamoClient;
 let putItemCommand;
@@ -32,11 +33,32 @@ export const createHandler = ({
     });
   }
 
+  if (!isAllowedOrigin(event)) {
+    return jsonResponse(403, {
+      success: false,
+      message: 'Recipe submissions are not available from this origin.',
+    });
+  }
+
+  if (!isJsonContentType(event)) {
+    return jsonResponse(415, {
+      success: false,
+      message: 'Please send recipe submissions as JSON.',
+    });
+  }
+
   let body;
 
   try {
-    body = parseBody(event);
-  } catch {
+    body = parseBody(event, getMaxBodyBytes());
+  } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      return jsonResponse(413, {
+        success: false,
+        message: 'Please shorten your recipe idea and try again.',
+      });
+    }
+
     return jsonResponse(400, {
       success: false,
       message: 'Please send a valid JSON recipe submission.',
@@ -107,11 +129,15 @@ function getMethod(event) {
   return event.requestContext?.http?.method ?? event.httpMethod ?? '';
 }
 
-function parseBody(event) {
+function parseBody(event, maxBodyBytes) {
   const rawBody = event.isBase64Encoded ? Buffer.from(event.body ?? '', 'base64').toString('utf8') : event.body;
 
   if (!rawBody) {
     throw new Error('Missing body');
+  }
+
+  if (Buffer.byteLength(rawBody, 'utf8') > maxBodyBytes) {
+    throw new RequestBodyTooLargeError();
   }
 
   const parsed = JSON.parse(rawBody);
@@ -121,6 +147,40 @@ function parseBody(event) {
   }
 
   return parsed;
+}
+
+function isAllowedOrigin(event) {
+  const origin = getHeader(event, 'origin');
+
+  if (!origin) {
+    return true;
+  }
+
+  const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return allowedOrigins.length === 0 || allowedOrigins.includes(origin);
+}
+
+function isJsonContentType(event) {
+  const contentType = getHeader(event, 'content-type');
+
+  return !contentType || contentType.toLowerCase().includes('application/json');
+}
+
+function getHeader(event, headerName) {
+  const headers = event.headers || {};
+  const matchingKey = Object.keys(headers).find((key) => key.toLowerCase() === headerName);
+
+  return matchingKey ? headers[matchingKey] : '';
+}
+
+function getMaxBodyBytes() {
+  const configuredLimit = Number.parseInt(process.env.RECIPE_SUBMISSIONS_MAX_BODY_BYTES || '', 10);
+
+  return Number.isFinite(configuredLimit) && configuredLimit > 0 ? configuredLimit : DEFAULT_MAX_BODY_BYTES;
 }
 
 function normalizeBody(body) {
@@ -334,3 +394,5 @@ function jsonResponse(statusCode, body) {
     body: JSON.stringify(body),
   };
 }
+
+class RequestBodyTooLargeError extends Error {}

--- a/infra/lambda/recipe-submissions/index.test.mjs
+++ b/infra/lambda/recipe-submissions/index.test.mjs
@@ -11,6 +11,9 @@ function createEvent(body, method = 'POST') {
         method,
       },
     },
+    headers: {
+      'content-type': 'application/json',
+    },
     body: JSON.stringify(body),
   };
 }
@@ -114,6 +117,7 @@ test('rejects malformed JSON cleanly', async () => {
 
   const response = await handler({
     requestContext: { http: { method: 'POST' } },
+    headers: { 'content-type': 'application/json' },
     body: '{nope',
   });
 
@@ -134,6 +138,62 @@ test('rejects non-POST requests cleanly', async () => {
     success: false,
     message: 'Recipe submissions only accept POST requests.',
   });
+});
+
+test('rejects disallowed browser origins', async () => {
+  process.env.ALLOWED_ORIGINS = 'https://drakesfood.com,http://localhost:4200';
+  const handler = createHandler({ saveSubmission: async () => undefined });
+
+  const response = await handler({
+    ...createEvent({ title: 'Pizza', description: 'Try this.' }),
+    headers: {
+      'content-type': 'application/json',
+      origin: 'https://spam.example',
+    },
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Recipe submissions are not available from this origin.',
+  });
+  delete process.env.ALLOWED_ORIGINS;
+});
+
+test('rejects unsupported content types', async () => {
+  const handler = createHandler({ saveSubmission: async () => undefined });
+
+  const response = await handler({
+    ...createEvent({ title: 'Pizza', description: 'Try this.' }),
+    headers: {
+      'content-type': 'text/plain',
+    },
+  });
+
+  assert.equal(response.statusCode, 415);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Please send recipe submissions as JSON.',
+  });
+});
+
+test('rejects oversized request bodies before parsing', async () => {
+  process.env.RECIPE_SUBMISSIONS_MAX_BODY_BYTES = '32';
+  const handler = createHandler({ saveSubmission: async () => undefined });
+
+  const response = await handler(
+    createEvent({
+      title: 'Pizza',
+      description: 'This body is intentionally too long for the configured test limit.',
+    }),
+  );
+
+  assert.equal(response.statusCode, 413);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Please shorten your recipe idea and try again.',
+  });
+  delete process.env.RECIPE_SUBMISSIONS_MAX_BODY_BYTES;
 });
 
 test('rejects invalid optional email and URL values', async () => {
@@ -176,6 +236,7 @@ test('parses base64-encoded request bodies', async () => {
 
   const response = await handler({
     requestContext: { http: { method: 'POST' } },
+    headers: { 'content-type': 'application/json' },
     isBase64Encoded: true,
     body: encodedBody,
   });

--- a/infra/recipe_submissions.tf
+++ b/infra/recipe_submissions.tf
@@ -108,11 +108,12 @@ resource "aws_lambda_function" "recipe_submissions" {
 
   environment {
     variables = {
-      ALLOWED_ORIGINS                = join(",", var.recipe_submissions_allowed_origins)
-      RECIPE_SUBMISSIONS_TABLE_NAME  = aws_dynamodb_table.recipe_submissions.name
-      RECIPE_SUBMISSIONS_SOURCE_SITE = var.recipe_submissions_source_site
-      SES_RECIPIENT_EMAIL            = var.recipe_submissions_ses_recipient_email
-      SES_SENDER_EMAIL               = var.recipe_submissions_ses_sender_email
+      ALLOWED_ORIGINS                   = join(",", var.recipe_submissions_allowed_origins)
+      RECIPE_SUBMISSIONS_MAX_BODY_BYTES = tostring(var.recipe_submissions_max_body_bytes)
+      RECIPE_SUBMISSIONS_TABLE_NAME     = aws_dynamodb_table.recipe_submissions.name
+      RECIPE_SUBMISSIONS_SOURCE_SITE    = var.recipe_submissions_source_site
+      SES_RECIPIENT_EMAIL               = var.recipe_submissions_ses_recipient_email
+      SES_SENDER_EMAIL                  = var.recipe_submissions_ses_sender_email
     }
   }
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -56,6 +56,12 @@ variable "recipe_submissions_log_retention_days" {
   default     = 30
 }
 
+variable "recipe_submissions_max_body_bytes" {
+  description = "Maximum request body size accepted by the recipe submission Lambda."
+  type        = number
+  default     = 16384
+}
+
 variable "recipe_submissions_ses_identity_arn" {
   description = "Optional SES identity ARN allowed to send recipe submission emails. Defaults to the domain identity for the active AWS account."
   type        = string


### PR DESCRIPTION
## Summary
- Add Lambda-side browser origin enforcement using the configured allowlist in addition to API Gateway CORS.
- Require JSON request bodies and reject oversized request bodies before parsing with a configurable byte limit.
- Expand handler tests for disallowed origins, unsupported content types, and oversized payloads.
- Document V1 security behavior, throttling, request limits, and the no-CAPTCHA decision.

Closes #30

## Validation
- `node --test infra/lambda/recipe-submissions/index.test.mjs` passed.
- `tofu fmt -check -recursive` passed.
- `tofu validate` passed.
- `AWS_PROFILE=drakesfood tofu plan -input=false` passed: 11 to add, 0 to change, 0 to destroy.
- `npm run typecheck` passed.
- `npm run build` passed.
- `npm run lint` passed.
- `git diff --check` passed.

Note: local Node emitted a warning because the active shell is using `v25.9.0`; the repo expects Node 22 LTS. Validation still completed successfully.

## Visual Review
- Not applicable; backend/security infrastructure change only.

## Known Notes
- No infrastructure was applied.
- V1 intentionally does not include CAPTCHA unless real abuse requires it later.