### PR TITLE
Add RecipeSensei support and privacy pages

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,4 +5,14 @@
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://drakesfood.com/recipesensei/support</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://drakesfood.com/recipesensei/privacy</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,13 +1,7 @@
 <div class="page-shell">
   <a class="skip-link" href="#main-content">Skip to content</a>
   <main id="main-content">
-    <app-hero></app-hero>
-    <app-gallery-preview></app-gallery-preview>
-    <app-instagram-cta></app-instagram-cta>
-    <app-about></app-about>
-    <app-recipe-sensei></app-recipe-sensei>
-    <app-recipe-submission></app-recipe-submission>
-    <app-recipe-blog></app-recipe-blog>
+    <router-outlet></router-outlet>
   </main>
   <app-site-footer></app-site-footer>
 </div>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -7,4 +7,5 @@ export const routes: Routes = [
   { path: '', component: HomePageComponent },
   { path: 'recipesensei/support', component: RecipeSenseiSupportPageComponent },
   { path: 'recipesensei/privacy', component: RecipeSenseiPrivacyPageComponent },
+  { path: '**', redirectTo: '' },
 ];

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,10 @@
 import { Routes } from '@angular/router';
+import { HomePageComponent } from './pages/home-page/home-page.component';
+import { RecipeSenseiPrivacyPageComponent } from './pages/recipesensei-privacy-page/recipesensei-privacy-page.component';
+import { RecipeSenseiSupportPageComponent } from './pages/recipesensei-support-page/recipesensei-support-page.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', component: HomePageComponent },
+  { path: 'recipesensei/support', component: RecipeSenseiSupportPageComponent },
+  { path: 'recipesensei/privacy', component: RecipeSenseiPrivacyPageComponent },
+];

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,26 +1,11 @@
 import { Component } from '@angular/core';
-import { AboutComponent } from './components/about/about.component';
+import { RouterOutlet } from '@angular/router';
 import { FooterComponent } from './components/footer/footer.component';
-import { GalleryPreviewComponent } from './components/gallery-preview/gallery-preview.component';
-import { HeroComponent } from './components/hero/hero.component';
-import { InstagramCtaComponent } from './components/instagram-cta/instagram-cta.component';
-import { RecipeBlogComponent } from './components/recipe-blog/recipe-blog.component';
-import { RecipeSubmissionComponent } from './components/recipe-submission/recipe-submission.component';
-import { RecipeSenseiComponent } from './components/recipe-sensei/recipe-sensei.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [
-    HeroComponent,
-    GalleryPreviewComponent,
-    InstagramCtaComponent,
-    AboutComponent,
-    RecipeSenseiComponent,
-    RecipeSubmissionComponent,
-    RecipeBlogComponent,
-    FooterComponent,
-  ],
+  imports: [RouterOutlet, FooterComponent],
   templateUrl: './app.html',
   styleUrls: ['./app.css'],
 })

--- a/src/app/components/footer/footer.component.css
+++ b/src/app/components/footer/footer.component.css
@@ -4,9 +4,16 @@
   color: var(--color-text-soft);
 }
 
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  justify-content: center;
+  margin-top: 0.75rem;
+}
+
 .site-footer .footer-link {
   display: inline-block;
-  margin-top: 0.75rem;
   color: var(--color-purple-dark);
   font-weight: 700;
 }

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,4 +1,8 @@
 <footer class="site-footer">
   <p>Drake's Food — a warm food portfolio created for friends, family, and future RecipeSensei visitors.</p>
-  <a class="footer-link" href="https://instagram.com/drakesfood" target="_blank" rel="noopener" aria-label="Visit @drakesfood on Instagram, opens in a new tab">@drakesfood</a>
+  <nav class="footer-links" aria-label="Footer links">
+    <a class="footer-link" href="https://instagram.com/drakesfood" target="_blank" rel="noopener" aria-label="Visit @drakesfood on Instagram, opens in a new tab">@drakesfood</a>
+    <a class="footer-link" routerLink="/recipesensei/support">RecipeSensei Support</a>
+    <a class="footer-link" routerLink="/recipesensei/privacy">Privacy Policy</a>
+  </nav>
 </footer>

--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-site-footer',
   standalone: true,
+  imports: [RouterLink],
   templateUrl: './footer.component.html',
   styleUrls: ['./footer.component.css'],
 })

--- a/src/app/components/recipe-sensei/recipe-sensei.component.css
+++ b/src/app/components/recipe-sensei/recipe-sensei.component.css
@@ -18,6 +18,13 @@
   line-height: 1.8;
 }
 
+.teaser-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
 .badge {
   display: inline-flex;
   padding: 0.8rem 1.2rem;

--- a/src/app/components/recipe-sensei/recipe-sensei.component.html
+++ b/src/app/components/recipe-sensei/recipe-sensei.component.html
@@ -6,6 +6,10 @@
   <div class="teaser-card">
     <div>
       <p>RecipeSensei is a future home for guided recipes, meal ideas, and food workflow inspiration. Drake is building it with the same warm, accessible approach as this site.</p>
+      <div class="teaser-actions" aria-label="RecipeSensei links">
+        <a class="button button-secondary" href="/recipesensei/support">Support</a>
+        <a class="button button-secondary" href="/recipesensei/privacy">Privacy Policy</a>
+      </div>
     </div>
     <span class="badge">Coming soon</span>
   </div>

--- a/src/app/pages/home-page/home-page.component.html
+++ b/src/app/pages/home-page/home-page.component.html
@@ -1,0 +1,7 @@
+<app-hero></app-hero>
+<app-gallery-preview></app-gallery-preview>
+<app-instagram-cta></app-instagram-cta>
+<app-about></app-about>
+<app-recipe-sensei></app-recipe-sensei>
+<app-recipe-submission></app-recipe-submission>
+<app-recipe-blog></app-recipe-blog>

--- a/src/app/pages/home-page/home-page.component.ts
+++ b/src/app/pages/home-page/home-page.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { AboutComponent } from '../../components/about/about.component';
+import { GalleryPreviewComponent } from '../../components/gallery-preview/gallery-preview.component';
+import { HeroComponent } from '../../components/hero/hero.component';
+import { InstagramCtaComponent } from '../../components/instagram-cta/instagram-cta.component';
+import { RecipeBlogComponent } from '../../components/recipe-blog/recipe-blog.component';
+import { RecipeSubmissionComponent } from '../../components/recipe-submission/recipe-submission.component';
+import { RecipeSenseiComponent } from '../../components/recipe-sensei/recipe-sensei.component';
+
+@Component({
+  selector: 'app-home-page',
+  standalone: true,
+  imports: [
+    HeroComponent,
+    GalleryPreviewComponent,
+    InstagramCtaComponent,
+    AboutComponent,
+    RecipeSenseiComponent,
+    RecipeSubmissionComponent,
+    RecipeBlogComponent,
+  ],
+  templateUrl: './home-page.component.html',
+})
+export class HomePageComponent {}

--- a/src/app/pages/recipesensei-privacy-page/recipesensei-privacy-page.component.css
+++ b/src/app/pages/recipesensei-privacy-page/recipesensei-privacy-page.component.css
@@ -1,0 +1,95 @@
+.legal-page {
+  display: grid;
+  gap: 1.5rem;
+  padding: 2rem 1rem 4rem;
+}
+
+.back-link,
+.legal-card a {
+  color: var(--color-purple-dark);
+  font-weight: 700;
+}
+
+.back-link {
+  text-decoration: none;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.legal-hero {
+  max-width: 780px;
+}
+
+.legal-hero h1 {
+  margin: 0.45rem 0 0;
+  font-size: clamp(2.4rem, 6vw, 4rem);
+  letter-spacing: -0.05em;
+  line-height: 1.02;
+}
+
+.legal-hero p:not(.eyebrow) {
+  margin-top: 1.2rem;
+  color: var(--color-text-muted);
+  font-size: 1.08rem;
+  line-height: 1.8;
+}
+
+.policy-stack {
+  display: grid;
+  gap: 1rem;
+  max-width: 900px;
+}
+
+.legal-card {
+  border: 1px solid rgba(109, 74, 163, 0.12);
+  border-radius: 1.5rem;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-card);
+  padding: 1.5rem;
+}
+
+.contact-card {
+  background:
+    linear-gradient(135deg, rgba(109, 74, 163, 0.1), transparent 48%),
+    var(--color-surface);
+}
+
+.legal-card h2 {
+  margin: 0;
+  font-size: clamp(1.35rem, 3vw, 1.8rem);
+}
+
+.legal-card p,
+.legal-card li {
+  color: var(--color-text-muted);
+  line-height: 1.8;
+}
+
+.legal-card p {
+  margin-top: 0.8rem;
+}
+
+.legal-card ul {
+  margin: 1rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.email-link {
+  display: inline-flex;
+  margin-top: 0.75rem;
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+@media (min-width: 760px) {
+  .legal-page {
+    gap: 2rem;
+    padding: 4rem clamp(2rem, 8vw, 6rem) 5rem;
+  }
+
+  .legal-card {
+    padding: 2rem;
+  }
+}

--- a/src/app/pages/recipesensei-privacy-page/recipesensei-privacy-page.component.html
+++ b/src/app/pages/recipesensei-privacy-page/recipesensei-privacy-page.component.html
@@ -1,0 +1,86 @@
+<section class="legal-page" aria-labelledby="privacy-title">
+  <a class="back-link" routerLink="/">Back to Drake's Food</a>
+
+  <div class="legal-hero">
+    <p class="eyebrow">RecipeSensei</p>
+    <h1 id="privacy-title">Privacy Policy</h1>
+    <p>Effective date: February 28, 2026. Last updated: May 1, 2026.</p>
+  </div>
+
+  <div class="policy-stack">
+    <article class="legal-card">
+      <h2>Overview</h2>
+      <p>RecipeSensei respects your privacy. This policy explains what information is used to provide the RecipeSensei mobile app and how you can contact Drake with questions.</p>
+    </article>
+
+    <article class="legal-card">
+      <h2>Information Used by the App</h2>
+      <ul>
+        <li>Recipe content you create or import, including titles, ingredients, steps, notes, tags, servings, source links, and optional recipe photos.</li>
+        <li>Feedback or support messages you choose to send.</li>
+        <li>Basic diagnostic and crash information provided by Apple if enabled by your device settings and Apple services.</li>
+      </ul>
+      <p>RecipeSensei does not collect precise location data through the app.</p>
+    </article>
+
+    <article class="legal-card">
+      <h2>Photos, Camera, and Recipe Import</h2>
+      <p>RecipeSensei may let you select images from your photo library, use the camera for live recipe scanning, or import recipe text and links you choose to share with the app.</p>
+      <p>Photo and camera access are requested and controlled by iOS system permissions and picker UI. You can revoke access at any time in iOS Settings.</p>
+    </article>
+
+    <article class="legal-card">
+      <h2>How Information Is Used</h2>
+      <ul>
+        <li>Provide core app functionality, including saving, organizing, importing, exporting, and displaying recipes.</li>
+        <li>Power recipe scanning and cleanup features.</li>
+        <li>Improve app reliability and performance.</li>
+        <li>Respond to support requests.</li>
+      </ul>
+      <p>RecipeSensei does not sell your personal information.</p>
+    </article>
+
+    <article class="legal-card">
+      <h2>AI and Text Processing</h2>
+      <p>RecipeSensei may use on-device or system-provided AI features to improve scanned recipe text quality, such as correcting OCR errors and formatting recipe details.</p>
+    </article>
+
+    <article class="legal-card">
+      <h2>Data Storage and Retention</h2>
+      <ul>
+        <li>Recipe data is stored on your device and/or in Apple-managed services used by your device configuration, such as iCloud backups if enabled by you.</li>
+        <li>Exported recipe files are created only when you choose to share or export them.</li>
+        <li>Support communications are retained only as long as needed to respond and maintain service quality.</li>
+      </ul>
+    </article>
+
+    <article class="legal-card">
+      <h2>Sharing and Your Choices</h2>
+      <p>RecipeSensei does not share your personal data with third parties for advertising. The app may rely on Apple platform services, such as app distribution and crash reporting, to operate.</p>
+      <ul>
+        <li>You can edit or delete recipe data within the app.</li>
+        <li>You can choose whether to import, export, or share recipe files.</li>
+        <li>You can remove app access to photos or camera in iOS Settings.</li>
+        <li>You can uninstall the app to stop further app use.</li>
+      </ul>
+    </article>
+
+    <article class="legal-card">
+      <h2>Children's Privacy</h2>
+      <p>RecipeSensei is not directed to children under 13, and Drake does not knowingly collect personal information from children under 13 through the app.</p>
+    </article>
+
+    <article class="legal-card">
+      <h2>Security and International Users</h2>
+      <p>Reasonable safeguards are used for a mobile app context. No method of transmission or storage is 100% secure.</p>
+      <p>If you use the app outside your country of residence, information may be processed where Apple or service infrastructure operates, subject to applicable law.</p>
+    </article>
+
+    <article class="legal-card contact-card">
+      <h2>Contact</h2>
+      <p>If you have questions about this Privacy Policy, contact Drake Robert.</p>
+      <a class="email-link" href="mailto:drakejrobert@gmail.com?subject=RecipeSensei%20Privacy">drakejrobert&#64;gmail.com</a>
+      <p><a routerLink="/recipesensei/support">Visit RecipeSensei Support</a></p>
+    </article>
+  </div>
+</section>

--- a/src/app/pages/recipesensei-privacy-page/recipesensei-privacy-page.component.ts
+++ b/src/app/pages/recipesensei-privacy-page/recipesensei-privacy-page.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-recipesensei-privacy-page',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './recipesensei-privacy-page.component.html',
+  styleUrls: ['./recipesensei-privacy-page.component.css'],
+})
+export class RecipeSenseiPrivacyPageComponent {}

--- a/src/app/pages/recipesensei-support-page/recipesensei-support-page.component.css
+++ b/src/app/pages/recipesensei-support-page/recipesensei-support-page.component.css
@@ -1,0 +1,95 @@
+.legal-page {
+  display: grid;
+  gap: 1.5rem;
+  padding: 2rem 1rem 4rem;
+}
+
+.back-link {
+  color: var(--color-purple-dark);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.legal-hero {
+  max-width: 760px;
+}
+
+.legal-hero h1 {
+  margin: 0.45rem 0 0;
+  font-size: clamp(2.4rem, 6vw, 4rem);
+  letter-spacing: -0.05em;
+  line-height: 1.02;
+}
+
+.legal-hero p:not(.eyebrow) {
+  margin-top: 1.2rem;
+  color: var(--color-text-muted);
+  font-size: 1.08rem;
+  line-height: 1.8;
+}
+
+.legal-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.legal-card {
+  border: 1px solid rgba(109, 74, 163, 0.12);
+  border-radius: 1.5rem;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-card);
+  padding: 1.5rem;
+}
+
+.contact-card {
+  background:
+    linear-gradient(135deg, rgba(109, 74, 163, 0.1), transparent 48%),
+    var(--color-surface);
+}
+
+.legal-card h2 {
+  margin: 0;
+  font-size: clamp(1.35rem, 3vw, 1.8rem);
+}
+
+.legal-card p,
+.legal-card li {
+  color: var(--color-text-muted);
+  line-height: 1.8;
+}
+
+.legal-card p {
+  margin-top: 0.8rem;
+}
+
+.legal-card ul {
+  margin: 1rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.legal-card .button {
+  margin-top: 1.2rem;
+}
+
+.email-link {
+  display: inline-flex;
+  margin-top: 0.75rem;
+  color: var(--color-purple-dark);
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+@media (min-width: 760px) {
+  .legal-page {
+    gap: 2rem;
+    padding: 4rem clamp(2rem, 8vw, 6rem) 5rem;
+  }
+
+  .legal-grid {
+    grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  }
+}

--- a/src/app/pages/recipesensei-support-page/recipesensei-support-page.component.html
+++ b/src/app/pages/recipesensei-support-page/recipesensei-support-page.component.html
@@ -1,0 +1,34 @@
+<section class="legal-page" aria-labelledby="support-title">
+  <a class="back-link" routerLink="/">Back to Drake's Food</a>
+
+  <div class="legal-hero">
+    <p class="eyebrow">RecipeSensei</p>
+    <h1 id="support-title">RecipeSensei Support</h1>
+    <p>Need help with RecipeSensei? Send app support questions, bug reports, recipe import issues, and feature requests to Drake.</p>
+  </div>
+
+  <div class="legal-grid">
+    <article class="legal-card contact-card">
+      <h2>Contact</h2>
+      <p>For support, email:</p>
+      <a class="email-link" href="mailto:drakejrobert@gmail.com?subject=RecipeSensei%20Support">drakejrobert&#64;gmail.com</a>
+    </article>
+
+    <article class="legal-card">
+      <h2>Helpful Details to Include</h2>
+      <ul>
+        <li>Your iPhone or iPad model</li>
+        <li>Your iOS or iPadOS version</li>
+        <li>Your RecipeSensei app version</li>
+        <li>What you were trying to do</li>
+        <li>Any recipe URL that failed to import</li>
+      </ul>
+    </article>
+  </div>
+
+  <article class="legal-card wide-card">
+    <h2>Privacy</h2>
+    <p>RecipeSensei is designed for personal recipe collections. You can review the current privacy details on the RecipeSensei privacy page.</p>
+    <a class="button button-secondary" routerLink="/recipesensei/privacy">View Privacy Policy</a>
+  </article>
+</section>

--- a/src/app/pages/recipesensei-support-page/recipesensei-support-page.component.ts
+++ b/src/app/pages/recipesensei-support-page/recipesensei-support-page.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-recipesensei-support-page',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './recipesensei-support-page.component.html',
+  styleUrls: ['./recipesensei-support-page.component.css'],
+})
+export class RecipeSenseiSupportPageComponent {}


### PR DESCRIPTION
## Summary
- Add routed RecipeSensei support and privacy pages for App Store support/legal URLs.
- Preserve the existing homepage behind a new home page wrapper and route shell.
- Link the new pages from the RecipeSensei teaser, footer, and sitemap.

## Validation
- npm run typecheck
- npm run build

## Follow-up
- Created issue #51 to replace the temporary Gmail contact with support@recipesensei.app.