### PR TITLE
Add RecipeSensei App Store link

### DIFF
--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -42,6 +42,7 @@
 - [x] Recipe submission email notifications added
 - [x] Recipe submission frontend wired to runtime-configured API
 - [x] Recipe submission system documentation added
+- [x] RecipeSensei App Store link added
 
 ## 🔄 In Progress
 
@@ -56,7 +57,7 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 
 - [ ] Finalize copy for all sections — #15
 - [ ] Add more gallery images or full gallery page (deferred for now) — #19
-- [ ] Add RecipeSensei launch details once available — #21
+- [x] Add RecipeSensei launch details once available — #21
 - [ ] Refine About section content — #16
 - [ ] Add optional recipe/blog details page later — #22
 - [ ] Add recipe submission security hardening — #30
@@ -98,7 +99,7 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - SEO follow-up added `Drakes Food`, `drakesfood`, and `@drakesfood` brand aliases plus `robots.txt` and `sitemap.xml`
 - CI now runs ESLint linting before type checking and production builds
 - Angular test runner setup remains deferred and tracked separately
-- RecipeSensei remains marked as "coming soon" until launch
+- RecipeSensei is live on the App Store: `https://apps.apple.com/us/app/recipesensei/id6759845210`
 - Instagram link remains `https://instagram.com/drakesfood`
 - Recipe submissions started with a frontend-only form section; live API wiring is now in progress.
 - Recipe submission API contract is documented before backend and infrastructure implementation.
@@ -121,4 +122,4 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 
 ## Last Updated
 
-April 30, 2026
+May 4, 2026

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,7 +1,8 @@
 <footer class="site-footer">
-  <p>Drake's Food — a warm food portfolio created for friends, family, and future RecipeSensei visitors.</p>
+  <p>Drake's Food — a warm food portfolio created for friends, family, and RecipeSensei visitors.</p>
   <nav class="footer-links" aria-label="Footer links">
     <a class="footer-link" href="https://instagram.com/drakesfood" target="_blank" rel="noopener" aria-label="Visit @drakesfood on Instagram, opens in a new tab">@drakesfood</a>
+    <a class="footer-link" href="https://apps.apple.com/us/app/recipesensei/id6759845210" target="_blank" rel="noopener" aria-label="Download RecipeSensei on the App Store, opens in a new tab">RecipeSensei App Store</a>
     <a class="footer-link" routerLink="/recipesensei/support">RecipeSensei Support</a>
     <a class="footer-link" routerLink="/recipesensei/privacy">Privacy Policy</a>
   </nav>

--- a/src/app/components/recipe-sensei/recipe-sensei.component.html
+++ b/src/app/components/recipe-sensei/recipe-sensei.component.html
@@ -5,12 +5,13 @@
   </div>
   <div class="teaser-card">
     <div>
-      <p>RecipeSensei is a future home for guided recipes, meal ideas, and food workflow inspiration. Drake is building it with the same warm, accessible approach as this site.</p>
+      <p>RecipeSensei is Drake's recipe-saving and cooking companion app, built to keep favorite recipes organized and easier to cook from anywhere.</p>
       <div class="teaser-actions" aria-label="RecipeSensei links">
+        <a class="button button-primary" href="https://apps.apple.com/us/app/recipesensei/id6759845210" target="_blank" rel="noopener" aria-label="Download RecipeSensei on the App Store, opens in a new tab">Download on the App Store</a>
         <a class="button button-secondary" href="/recipesensei/support">Support</a>
         <a class="button button-secondary" href="/recipesensei/privacy">Privacy Policy</a>
       </div>
     </div>
-    <span class="badge">Coming soon</span>
+    <span class="badge">Live on the App Store</span>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Updates the homepage RecipeSensei section now that the app is live.
- Adds the App Store link as the primary RecipeSensei CTA and in the footer.
- Updates `TODO_STATUS.md` to mark RecipeSensei launch details complete.

Closes #21
Refs #59

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Visual Review
- Not performed in a browser in this environment. Build validation completed successfully.

## Notes
- Angular reported the local Node.js version `v25.9.0` is not an LTS production version during lint/build, but both commands completed successfully.