### PR TITLE
Add multi-page Angular site structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Drake's Food
 
-A modern Angular portfolio website for Drake's Food. This first version is a warm, minimal, photo-forward homepage with food gallery preview, Instagram CTA, about section, RecipeSensei teaser, and a recipe/blog coming soon area.
+A modern Angular portfolio website for Drake's Food. This first version is a warm, minimal, photo-forward multi-page site with a food gallery preview, Instagram CTA, about section, RecipeSensei links, recipe idea submission, and a recipe/blog coming soon area.
 
 ## Getting started
 
@@ -48,12 +48,26 @@ npm run lint
 ## Project structure
 
 - `src/app/` - Angular components and app entrypoint
+- `src/app/pages/` - routed page components for the small static site
 - `src/app/data/` - placeholder gallery data
 - `src/assets/images/` - local placeholder food assets
 - `docs/` - feature contracts and implementation notes
 - `infra/` - OpenTofu infrastructure for S3, CloudFront, ACM, and Route 53
 - `.github/copilot-instructions.md` - project guidance for Copilot
 - `public/` - static assets for app build
+
+## Page structure
+
+The site uses Angular routes for the primary content areas while staying static-first:
+
+- `/` - homepage gateway with hero, gallery preview, Instagram CTA, About, RecipeSensei, submission, and recipes preview sections
+- `/gallery` - food gallery page
+- `/recipes` - recipes and stories coming soon page
+- `/submit` - recipe idea submission page
+- `/recipesensei` - RecipeSensei app teaser and links
+- `/about` - Drake's Food intro page
+- `/recipesensei/support` - RecipeSensei support page
+- `/recipesensei/privacy` - RecipeSensei privacy policy page
 
 ## Recipe submissions
 

--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -43,6 +43,7 @@
 - [x] Recipe submission frontend wired to runtime-configured API
 - [x] Recipe submission system documentation added
 - [x] RecipeSensei App Store link added
+- [x] Multi-page Angular site structure added — #54
 
 ## 🔄 In Progress
 
@@ -100,6 +101,7 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - Angular test runner setup remains deferred and tracked separately
 - RecipeSensei is live on the App Store: `https://apps.apple.com/us/app/recipesensei/id6759845210`
 - Instagram link remains `https://instagram.com/drakesfood`
+- Primary site routes now include `/`, `/gallery`, `/recipes`, `/submit`, `/recipesensei`, and `/about`, with RecipeSensei support and privacy pages preserved.
 - Recipe submissions started with a frontend-only form section; live API wiring is now in progress.
 - Recipe submission API contract is documented before backend and infrastructure implementation.
 - Recipe submission infrastructure is defined with OpenTofu using API Gateway, Lambda, DynamoDB, SES permissions, and CloudWatch logs.

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -7,6 +7,54 @@
   color: var(--color-text);
 }
 
+.site-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1rem 0 0.5rem;
+}
+
+.brand-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  width: fit-content;
+  color: var(--color-text);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.brand-link img {
+  width: 2.5rem;
+  height: 2.5rem;
+  object-fit: contain;
+}
+
+.primary-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.primary-nav a {
+  border: 1px solid rgba(109, 74, 163, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 250, 245, 0.68);
+  color: var(--color-text-muted);
+  padding: 0.7rem 0.9rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.primary-nav a:hover,
+.primary-nav .active-link {
+  background: var(--color-purple-dark);
+  color: #fff;
+}
+
 .skip-link {
   position: fixed;
   top: 1rem;
@@ -24,4 +72,18 @@
 
 .skip-link:focus-visible {
   transform: translateY(0);
+}
+
+@media (min-width: 800px) {
+  .site-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    width: min(1120px, calc(100% - 4rem));
+    padding-top: 1.25rem;
+  }
+
+  .primary-nav {
+    justify-content: flex-end;
+  }
 }

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,5 +1,19 @@
 <div class="page-shell">
   <a class="skip-link" href="#main-content">Skip to content</a>
+  <header class="site-header">
+    <a class="brand-link" routerLink="/" aria-label="Drake's Food home">
+      <img src="assets/images/chef-ninja-avatar-128.png" alt="" width="40" height="40" decoding="async" />
+      <span>Drake's Food</span>
+    </a>
+    <nav class="primary-nav" aria-label="Primary navigation">
+      <a routerLink="/" routerLinkActive="active-link" [routerLinkActiveOptions]="{ exact: true }">Home</a>
+      <a routerLink="/gallery" routerLinkActive="active-link">Gallery</a>
+      <a routerLink="/recipes" routerLinkActive="active-link">Recipes</a>
+      <a routerLink="/submit" routerLinkActive="active-link">Submit Idea</a>
+      <a routerLink="/recipesensei" routerLinkActive="active-link" [routerLinkActiveOptions]="{ exact: true }">RecipeSensei</a>
+      <a routerLink="/about" routerLinkActive="active-link">About</a>
+    </nav>
+  </header>
   <main id="main-content">
     <router-outlet></router-outlet>
   </main>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,11 +1,21 @@
 import { Routes } from '@angular/router';
+import { AboutPageComponent } from './pages/about-page/about-page.component';
+import { GalleryPageComponent } from './pages/gallery-page/gallery-page.component';
 import { HomePageComponent } from './pages/home-page/home-page.component';
+import { RecipeSenseiPageComponent } from './pages/recipesensei-page/recipesensei-page.component';
 import { RecipeSenseiPrivacyPageComponent } from './pages/recipesensei-privacy-page/recipesensei-privacy-page.component';
 import { RecipeSenseiSupportPageComponent } from './pages/recipesensei-support-page/recipesensei-support-page.component';
+import { RecipesPageComponent } from './pages/recipes-page/recipes-page.component';
+import { SubmitPageComponent } from './pages/submit-page/submit-page.component';
 
 export const routes: Routes = [
   { path: '', component: HomePageComponent },
+  { path: 'gallery', component: GalleryPageComponent },
+  { path: 'recipes', component: RecipesPageComponent },
+  { path: 'submit', component: SubmitPageComponent },
+  { path: 'recipesensei', component: RecipeSenseiPageComponent },
   { path: 'recipesensei/support', component: RecipeSenseiSupportPageComponent },
   { path: 'recipesensei/privacy', component: RecipeSenseiPrivacyPageComponent },
+  { path: 'about', component: AboutPageComponent },
   { path: '**', redirectTo: '' },
 ];

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { FooterComponent } from './components/footer/footer.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, FooterComponent],
+  imports: [RouterLink, RouterLinkActive, RouterOutlet, FooterComponent],
   templateUrl: './app.html',
   styleUrls: ['./app.css'],
 })

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,6 +1,10 @@
 <footer class="site-footer">
   <p>Drake's Food — a warm food portfolio created for friends, family, and RecipeSensei visitors.</p>
   <nav class="footer-links" aria-label="Footer links">
+    <a class="footer-link" routerLink="/gallery">Gallery</a>
+    <a class="footer-link" routerLink="/recipes">Recipes</a>
+    <a class="footer-link" routerLink="/submit">Submit an Idea</a>
+    <a class="footer-link" routerLink="/about">About</a>
     <a class="footer-link" href="https://instagram.com/drakesfood" target="_blank" rel="noopener noreferrer" aria-label="Visit @drakesfood on Instagram, opens in a new tab">@drakesfood</a>
     <a class="footer-link" href="https://apps.apple.com/us/app/recipesensei/id6759845210" target="_blank" rel="noopener noreferrer" aria-label="Download RecipeSensei on the App Store, opens in a new tab">RecipeSensei App Store</a>
     <a class="footer-link" routerLink="/recipesensei/support">RecipeSensei Support</a>

--- a/src/app/components/hero/hero.component.html
+++ b/src/app/components/hero/hero.component.html
@@ -8,8 +8,9 @@
     <p>Warm, photo-first food styling, home cooking, and a first look at RecipeSensei inspiration.</p>
     <div class="hero-actions">
       <a class="button button-primary" href="https://instagram.com/drakesfood" target="_blank" rel="noopener noreferrer" aria-label="Follow @drakesfood on Instagram, opens in a new tab">Follow @drakesfood</a>
-      <a class="button button-secondary" href="#gallery">View gallery</a>
-      <a class="button button-secondary" href="#submit-recipe">Submit a recipe idea</a>
+      <a class="button button-secondary" routerLink="/gallery">View gallery</a>
+      <a class="button button-secondary" routerLink="/recipesensei">RecipeSensei</a>
+      <a class="button button-secondary" routerLink="/submit">Submit a recipe idea</a>
     </div>
   </div>
   <div class="hero-image">

--- a/src/app/components/hero/hero.component.ts
+++ b/src/app/components/hero/hero.component.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-hero',
   standalone: true,
+  imports: [RouterLink],
   templateUrl: './hero.component.html',
   styleUrls: ['./hero.component.css'],
 })

--- a/src/app/components/recipe-sensei/recipe-sensei.component.html
+++ b/src/app/components/recipe-sensei/recipe-sensei.component.html
@@ -8,8 +8,8 @@
       <p>RecipeSensei is Drake's recipe-saving and cooking companion app, built to keep favorite recipes organized and easier to cook from anywhere.</p>
       <div class="teaser-actions" aria-label="RecipeSensei links">
         <a class="button button-primary" href="https://apps.apple.com/us/app/recipesensei/id6759845210" target="_blank" rel="noopener" aria-label="Download RecipeSensei on the App Store, opens in a new tab">Download on the App Store</a>
-        <a class="button button-secondary" href="/recipesensei/support">Support</a>
-        <a class="button button-secondary" href="/recipesensei/privacy">Privacy Policy</a>
+        <a class="button button-secondary" routerLink="/recipesensei/support">Support</a>
+        <a class="button button-secondary" routerLink="/recipesensei/privacy">Privacy Policy</a>
       </div>
       <p class="availability-note">Available for iPhone and iPad on the App Store.</p>
     </div>

--- a/src/app/components/recipe-sensei/recipe-sensei.component.ts
+++ b/src/app/components/recipe-sensei/recipe-sensei.component.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-recipe-sensei',
   standalone: true,
+  imports: [RouterLink],
   templateUrl: './recipe-sensei.component.html',
   styleUrls: ['./recipe-sensei.component.css'],
 })

--- a/src/app/components/submit-idea-cta/submit-idea-cta.component.css
+++ b/src/app/components/submit-idea-cta/submit-idea-cta.component.css
@@ -1,0 +1,37 @@
+.submit-idea-cta {
+  padding: 2rem 1rem;
+}
+
+.submit-idea-card {
+  display: grid;
+  gap: 1.5rem;
+  border: 1px solid rgba(109, 74, 163, 0.12);
+  border-radius: 1.75rem;
+  background:
+    linear-gradient(135deg, rgba(140, 90, 64, 0.12), transparent 42%),
+    var(--color-surface);
+  padding: 2rem;
+  box-shadow: var(--shadow-card);
+}
+
+.submit-idea-card h2 {
+  margin: 0;
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.submit-idea-card p {
+  margin: 0;
+  color: var(--color-text-muted);
+  line-height: 1.8;
+}
+
+.submit-idea-card .button {
+  justify-self: start;
+}
+
+@media (min-width: 900px) {
+  .submit-idea-card {
+    grid-template-columns: 1.4fr auto;
+    align-items: center;
+  }
+}

--- a/src/app/components/submit-idea-cta/submit-idea-cta.component.html
+++ b/src/app/components/submit-idea-cta/submit-idea-cta.component.html
@@ -1,0 +1,10 @@
+<section class="submit-idea-cta" aria-labelledby="submit-idea-cta-title">
+  <div class="submit-idea-card">
+    <div>
+      <p class="eyebrow">Cook this next</p>
+      <h2 id="submit-idea-cta-title">Have something Drake should try?</h2>
+      <p>Send a family recipe, cooking challenge, link, or loose idea. Submissions are reviewed manually and never auto-publish to the site.</p>
+    </div>
+    <a class="button button-primary" routerLink="/submit">Submit a recipe idea</a>
+  </div>
+</section>

--- a/src/app/components/submit-idea-cta/submit-idea-cta.component.ts
+++ b/src/app/components/submit-idea-cta/submit-idea-cta.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-submit-idea-cta',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './submit-idea-cta.component.html',
+  styleUrls: ['./submit-idea-cta.component.css'],
+})
+export class SubmitIdeaCtaComponent {}

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -1,0 +1,1 @@
+<app-about></app-about>

--- a/src/app/pages/about-page/about-page.component.ts
+++ b/src/app/pages/about-page/about-page.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { AboutComponent } from '../../components/about/about.component';
+
+@Component({
+  selector: 'app-about-page',
+  standalone: true,
+  imports: [AboutComponent],
+  templateUrl: './about-page.component.html',
+})
+export class AboutPageComponent {}

--- a/src/app/pages/gallery-page/gallery-page.component.html
+++ b/src/app/pages/gallery-page/gallery-page.component.html
@@ -1,0 +1,1 @@
+<app-gallery-preview></app-gallery-preview>

--- a/src/app/pages/gallery-page/gallery-page.component.ts
+++ b/src/app/pages/gallery-page/gallery-page.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { GalleryPreviewComponent } from '../../components/gallery-preview/gallery-preview.component';
+
+@Component({
+  selector: 'app-gallery-page',
+  standalone: true,
+  imports: [GalleryPreviewComponent],
+  templateUrl: './gallery-page.component.html',
+})
+export class GalleryPageComponent {}

--- a/src/app/pages/home-page/home-page.component.html
+++ b/src/app/pages/home-page/home-page.component.html
@@ -3,5 +3,5 @@
 <app-instagram-cta></app-instagram-cta>
 <app-about></app-about>
 <app-recipe-sensei></app-recipe-sensei>
-<app-recipe-submission></app-recipe-submission>
+<app-submit-idea-cta></app-submit-idea-cta>
 <app-recipe-blog></app-recipe-blog>

--- a/src/app/pages/home-page/home-page.component.ts
+++ b/src/app/pages/home-page/home-page.component.ts
@@ -4,8 +4,8 @@ import { GalleryPreviewComponent } from '../../components/gallery-preview/galler
 import { HeroComponent } from '../../components/hero/hero.component';
 import { InstagramCtaComponent } from '../../components/instagram-cta/instagram-cta.component';
 import { RecipeBlogComponent } from '../../components/recipe-blog/recipe-blog.component';
-import { RecipeSubmissionComponent } from '../../components/recipe-submission/recipe-submission.component';
 import { RecipeSenseiComponent } from '../../components/recipe-sensei/recipe-sensei.component';
+import { SubmitIdeaCtaComponent } from '../../components/submit-idea-cta/submit-idea-cta.component';
 
 @Component({
   selector: 'app-home-page',
@@ -16,7 +16,7 @@ import { RecipeSenseiComponent } from '../../components/recipe-sensei/recipe-sen
     InstagramCtaComponent,
     AboutComponent,
     RecipeSenseiComponent,
-    RecipeSubmissionComponent,
+    SubmitIdeaCtaComponent,
     RecipeBlogComponent,
   ],
   templateUrl: './home-page.component.html',

--- a/src/app/pages/recipes-page/recipes-page.component.html
+++ b/src/app/pages/recipes-page/recipes-page.component.html
@@ -1,0 +1,1 @@
+<app-recipe-blog></app-recipe-blog>

--- a/src/app/pages/recipes-page/recipes-page.component.ts
+++ b/src/app/pages/recipes-page/recipes-page.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { RecipeBlogComponent } from '../../components/recipe-blog/recipe-blog.component';
+
+@Component({
+  selector: 'app-recipes-page',
+  standalone: true,
+  imports: [RecipeBlogComponent],
+  templateUrl: './recipes-page.component.html',
+})
+export class RecipesPageComponent {}

--- a/src/app/pages/recipesensei-page/recipesensei-page.component.html
+++ b/src/app/pages/recipesensei-page/recipesensei-page.component.html
@@ -1,0 +1,1 @@
+<app-recipe-sensei></app-recipe-sensei>

--- a/src/app/pages/recipesensei-page/recipesensei-page.component.ts
+++ b/src/app/pages/recipesensei-page/recipesensei-page.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { RecipeSenseiComponent } from '../../components/recipe-sensei/recipe-sensei.component';
+
+@Component({
+  selector: 'app-recipesensei-page',
+  standalone: true,
+  imports: [RecipeSenseiComponent],
+  templateUrl: './recipesensei-page.component.html',
+})
+export class RecipeSenseiPageComponent {}

--- a/src/app/pages/submit-page/submit-page.component.html
+++ b/src/app/pages/submit-page/submit-page.component.html
@@ -1,0 +1,1 @@
+<app-recipe-submission></app-recipe-submission>

--- a/src/app/pages/submit-page/submit-page.component.ts
+++ b/src/app/pages/submit-page/submit-page.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { RecipeSubmissionComponent } from '../../components/recipe-submission/recipe-submission.component';
+
+@Component({
+  selector: 'app-submit-page',
+  standalone: true,
+  imports: [RecipeSubmissionComponent],
+  templateUrl: './submit-page.component.html',
+})
+export class SubmitPageComponent {}


### PR DESCRIPTION
## Summary
- Adds primary Angular routes for Gallery, Recipes, Submit, RecipeSensei, and About pages.
- Adds a responsive primary navigation and footer links for the multi-page site structure.
- Moves the full recipe submission form to `/submit` and replaces it on the homepage with a lightweight CTA.

Closes #54

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Visual Review
- Not completed in-browser from this CLI session.
- Navigation and route wiring were validated by Angular lint/typecheck/build.

## Notes
- Existing follow-up issue #61 covers refining the dedicated Submit an Idea page/flow.
- Validation ran with active Node `v25.9.0`, which emitted Angular's odd-numbered Node warning. The repo pins Node 22 in `.nvmrc`, but `nvm` was not available at the expected path in this shell.