### PR TITLE
Document production routing verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ The site deploys built Angular assets to the existing `drakesfood.com` S3 bucket
 
 See `infra/README.md` for the one-time OpenTofu setup and required GitHub repository secrets/variables.
 
+## Production Routing
+
+The canonical public URL is `https://drakesfood.com/`. The `www.drakesfood.com` hostname is also served by the same CloudFront distribution for compatibility, but page metadata, sitemap entries, and structured data should point to the apex domain.
+
+CloudFront redirects plain HTTP requests to HTTPS and maps S3 `403`/`404` responses back to `/index.html` so direct refreshes of Angular routes such as `/gallery`, `/recipes`, `/submit`, `/recipesensei`, and `/about` load the static app instead of an S3 error page.
+
 ## Notes
 
 The site is intentionally mostly static. It is designed for AWS S3 + CloudFront and does not include authentication, backend services, or CMS tools.

--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -44,10 +44,11 @@
 - [x] Recipe submission system documentation added
 - [x] RecipeSensei App Store link added
 - [x] Multi-page Angular site structure added — #54
+- [x] Add recipe submission security and spam hardening — #30
 
 ## 🔄 In Progress
 
-- [ ] Add recipe submission security and spam hardening — #30
+- [ ] Verify canonical domain, HTTPS, and Angular route refresh behavior — #53
 
 ## 📋 Remaining Tasks
 
@@ -60,7 +61,6 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - [x] Add RecipeSensei launch details once available — #21
 - [ ] Refine About section content — #16
 - [ ] Add optional recipe/blog details page later — #22
-- [ ] Add recipe submission security hardening — #30
 
 ### Deployment & Infrastructure
 
@@ -102,6 +102,8 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - RecipeSensei is live on the App Store: `https://apps.apple.com/us/app/recipesensei/id6759845210`
 - Instagram link remains `https://instagram.com/drakesfood`
 - Primary site routes now include `/`, `/gallery`, `/recipes`, `/submit`, `/recipesensei`, and `/about`, with RecipeSensei support and privacy pages preserved.
+- Canonical production URL is `https://drakesfood.com/`; `www.drakesfood.com` serves the same CloudFront-backed site for compatibility while canonical metadata and sitemap entries use the apex domain.
+- Production route refresh checks confirmed that `/gallery`, `/recipes`, `/submit`, `/recipesensei`, and `/about` return the Angular app with `200` responses through the CloudFront SPA fallback.
 - Recipe submissions started with a frontend-only form section; live API wiring is now in progress.
 - Recipe submission API contract is documented before backend and infrastructure implementation.
 - Recipe submission infrastructure is defined with OpenTofu using API Gateway, Lambda, DynamoDB, SES permissions, and CloudWatch logs.

--- a/infra/README.md
+++ b/infra/README.md
@@ -142,4 +142,6 @@ After DNS propagation, these URLs should work:
 - `https://drakesfood.com`
 - `https://www.drakesfood.com`
 
-Plain HTTP requests should redirect to HTTPS.
+The canonical URL is `https://drakesfood.com/`. The `www` hostname intentionally serves the same site through the same CloudFront distribution for compatibility; canonical metadata and sitemap URLs should continue to use the apex domain.
+
+Plain HTTP requests should redirect to HTTPS. Direct refreshes for Angular routes should return the app with a `200` response because CloudFront maps S3 `403` and `404` responses to `/index.html`.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -6,6 +6,31 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://drakesfood.com/gallery</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://drakesfood.com/recipes</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://drakesfood.com/submit</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://drakesfood.com/recipesensei</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://drakesfood.com/about</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://drakesfood.com/recipesensei/support</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>


### PR DESCRIPTION
## Summary
- Documents the canonical apex domain and intentional `www` compatibility behavior.
- Documents CloudFront HTTP-to-HTTPS and Angular SPA route refresh fallback behavior.
- Updates the sitemap with the new primary multi-page routes and refreshes TODO status for #53.

Closes #53

## Production Verification
- `http://drakesfood.com` redirects to `https://drakesfood.com/`.
- `http://www.drakesfood.com` redirects to `https://www.drakesfood.com/`.
- `https://drakesfood.com/gallery` returns `200`.
- `https://drakesfood.com/recipes` returns `200`.
- `https://drakesfood.com/submit` returns `200`.
- `https://drakesfood.com/recipesensei` returns `200`.
- `https://drakesfood.com/about` returns `200`.
- `https://drakesfood.com/not-a-real-page` returns the Angular app through the CloudFront SPA fallback.

## Validation
- `npm run typecheck`
- `npm run build`
- `npm run lint`

## Notes
- Build and lint passed, but Angular warned that local Node is `v25.9.0`; the repo expects Node 22 LTS via `.nvmrc`.
- No infrastructure resource changes were made.