### PR TITLE
Redesign homepage hero CTAs

### DIFF
--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -47,10 +47,12 @@
 - [x] Add recipe submission security and spam hardening — #30
 - [x] Verify canonical domain, HTTPS, and Angular route refresh behavior — #53
 - [x] Build a full gallery page with reusable food cards — #56
+- [x] Add image optimization and responsive image guidelines — #57
+- [x] Redesign homepage hero and primary calls-to-action — #55
 
 ## 🔄 In Progress
 
-- [ ] Add image optimization and responsive image guidelines — #57
+- [ ] No active issue-scoped work after #55 validation
 
 ## 📋 Remaining Tasks
 
@@ -126,7 +128,8 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - Tablet hero image height is capped to avoid an oversized single-column hero before the desktop breakpoint
 - GitHub Issues are now the source of truth for active task tracking; `TODO_STATUS.md` is a high-level snapshot
 - Performance review removed the external Google Fonts request and added explicit sizing/decoding hints to key images
-- Issue #19 was closed as stale because the full gallery page work landed through #56; image follow-up continues in #57.
+- Issue #19 was closed as stale because the full gallery page work landed through #56; image follow-up landed through #57.
+- Homepage hero now leads with a clearer Drake's Food introduction, stronger gallery/Instagram/RecipeSensei CTAs, and a lighter submit-idea prompt.
 
 ## Last Updated
 

--- a/src/app/components/hero/hero.component.css
+++ b/src/app/components/hero/hero.component.css
@@ -38,18 +38,40 @@
   letter-spacing: -0.05rem;
 }
 
-.hero-content > p {
+.hero-lede,
+.hero-support {
   margin: 1.25rem 0 0;
   max-width: 40rem;
   line-height: 1.85;
   color: var(--color-text-muted);
 }
 
+.hero-lede {
+  font-size: clamp(1.08rem, 2vw, 1.28rem);
+  color: var(--color-text);
+}
+
+.hero-support {
+  margin-top: 0.8rem;
+}
+
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 1.5rem;
+  gap: 0.9rem;
   margin-top: 1.75rem;
+}
+
+.hero-note {
+  margin: 1rem 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.98rem;
+  line-height: 1.7;
+}
+
+.hero-note a {
+  color: var(--color-purple-dark);
+  font-weight: 800;
 }
 
 .hero-image img {
@@ -59,6 +81,12 @@
   border-radius: 1.5rem;
   object-fit: cover;
   box-shadow: var(--shadow-photo);
+}
+
+@media (max-width: 560px) {
+  .hero-actions .button {
+    width: 100%;
+  }
 }
 
 @media (min-width: 900px) {

--- a/src/app/components/hero/hero.component.html
+++ b/src/app/components/hero/hero.component.html
@@ -4,14 +4,15 @@
       <img src="assets/images/chef-ninja-avatar-128.png" alt="Drake's Food ninja chef mascot" width="96" height="96" decoding="async" />
       <p class="eyebrow">Drake's Food</p>
     </div>
-    <h1 id="hero-title">Every plate tells a story.</h1>
-    <p>Warm, photo-first food styling, home cooking, and a first look at RecipeSensei inspiration.</p>
+    <h1 id="hero-title">Drake’s Food</h1>
+    <p class="hero-lede">Home cooking, smoked meats, family meals, and food experiments from my kitchen.</p>
+    <p class="hero-support">Follow along for food photography, recipe ideas, cooking notes, and updates as RecipeSensei keeps coming together.</p>
     <div class="hero-actions">
-      <a class="button button-primary" href="https://instagram.com/drakesfood" target="_blank" rel="noopener noreferrer" aria-label="Follow @drakesfood on Instagram, opens in a new tab">Follow @drakesfood</a>
-      <a class="button button-secondary" routerLink="/gallery">View gallery</a>
-      <a class="button button-secondary" routerLink="/recipesensei">RecipeSensei</a>
-      <a class="button button-secondary" routerLink="/submit">Submit a recipe idea</a>
+      <a class="button button-primary" routerLink="/gallery">View food gallery</a>
+      <a class="button button-secondary" href="https://instagram.com/drakesfood" target="_blank" rel="noopener noreferrer" aria-label="Follow @drakesfood on Instagram, opens in a new tab">Follow @drakesfood</a>
+      <a class="button button-secondary" routerLink="/recipesensei">Explore RecipeSensei</a>
     </div>
+    <p class="hero-note">Have an idea for what I should cook next? <a routerLink="/submit">Send it my way</a>.</p>
   </div>
   <div class="hero-image">
     <img src="assets/images/markaritaOoniPizza.jpeg" alt="Margarita pizza fresh from the Ooni oven with melted mozzarella and basil" width="1280" height="1600" fetchpriority="high" decoding="async" />

--- a/src/app/components/recipe-blog/recipe-blog.component.css
+++ b/src/app/components/recipe-blog/recipe-blog.component.css
@@ -8,3 +8,20 @@
   color: var(--color-text-muted);
   line-height: 1.8;
 }
+
+.recipe-blog .button {
+  margin-top: 1.5rem;
+}
+
+.recipe-blog-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+}
+
+@media (max-width: 560px) {
+  .recipe-blog .button,
+  .recipe-blog-actions {
+    width: 100%;
+  }
+}

--- a/src/app/components/recipe-blog/recipe-blog.component.html
+++ b/src/app/components/recipe-blog/recipe-blog.component.html
@@ -1,7 +1,23 @@
 <section class="recipe-blog" aria-labelledby="recipes-title">
   <div class="section-intro">
     <p class="eyebrow">Recipes & stories</p>
-    <h2 id="recipes-title">A recipe blog is on the way.</h2>
+    <h2 id="recipes-title">
+      @if (variant === 'page') {
+        Recipes are coming soon.
+      } @else {
+        A recipe blog is on the way.
+      }
+    </h2>
   </div>
-  <p>The collection of recipes and food writing will expand here once the kitchen notes are ready to share. Have something Drake should cook? Send a recipe idea above.</p>
+  @if (variant === 'page') {
+    <p>The collection of recipes and food writing will grow here once the kitchen notes are ready to share. Expect home-cooking notes, experiments, family favorites, and the occasional smoked meat deep dive.</p>
+    <p>Have something Drake should cook? Send a recipe idea from the submit page.</p>
+    <a class="button button-primary" routerLink="/submit">Submit a recipe idea</a>
+  } @else {
+    <p>Recipes and cooking notes are coming soon. Head to the recipe page for updates as posts start landing, or send an idea for what Drake should cook next.</p>
+    <div class="recipe-blog-actions">
+      <a class="button button-primary" routerLink="/recipes">Visit recipes</a>
+      <a class="button button-secondary" routerLink="/submit">Submit a recipe idea</a>
+    </div>
+  }
 </section>

--- a/src/app/components/recipe-blog/recipe-blog.component.ts
+++ b/src/app/components/recipe-blog/recipe-blog.component.ts
@@ -1,9 +1,16 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+type RecipeBlogVariant = 'teaser' | 'page';
 
 @Component({
   selector: 'app-recipe-blog',
   standalone: true,
+  imports: [RouterLink],
   templateUrl: './recipe-blog.component.html',
   styleUrls: ['./recipe-blog.component.css'],
 })
-export class RecipeBlogComponent {}
+export class RecipeBlogComponent {
+  @Input()
+  variant: RecipeBlogVariant = 'teaser';
+}

--- a/src/app/pages/home-page/home-page.component.html
+++ b/src/app/pages/home-page/home-page.component.html
@@ -4,4 +4,4 @@
 <app-about></app-about>
 <app-recipe-sensei></app-recipe-sensei>
 <app-submit-idea-cta></app-submit-idea-cta>
-<app-recipe-blog></app-recipe-blog>
+<app-recipe-blog variant="teaser"></app-recipe-blog>

--- a/src/app/pages/recipes-page/recipes-page.component.html
+++ b/src/app/pages/recipes-page/recipes-page.component.html
@@ -1,1 +1,1 @@
-<app-recipe-blog></app-recipe-blog>
+<app-recipe-blog variant="page"></app-recipe-blog>


### PR DESCRIPTION
## Summary
- Reworks the homepage hero copy to clearly introduce Drake's Food around home cooking, smoked meats, family meals, and food experiments.
- Strengthens the primary CTA flow for gallery, Instagram, and RecipeSensei, with a lighter submit-idea prompt.
- Splits the recipes section into a homepage teaser and a dedicated `/recipes` coming-soon page variant.

Closes #55

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Visual Review
- Not run in browser during this pass; changes were validated through build/lint/typecheck only.

## Notes
- Local Node emitted the existing odd-version warning for `v25.9.0`, but validation passed.