### PR TITLE
Expand SEO metadata and simplify homepage CTAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ For new food photos:
 
 ## SEO and metadata
 
-The Angular app updates page titles, meta descriptions, canonical URLs, Open Graph tags, and Twitter/X card tags when primary routes change. Keep canonical metadata pointed at the apex domain, `https://drakesfood.com`, and use the default food photo preview image unless a future route has a stronger route-specific image.
+The Angular app updates page titles, meta descriptions, canonical URLs, Open Graph tags, and Twitter/X card tags when primary routes change. The production build also runs `scripts/generate-route-html.mjs`, which writes static route-specific `index.html` files so crawlers that do not execute JavaScript still receive the correct metadata for known routes. Keep canonical metadata pointed at the apex domain, `https://drakesfood.com`, and use the default food photo preview image unless a future route has a stronger route-specific image.
 
-When adding public pages, add route metadata in `src/app/app.ts` and include the canonical page in `public/sitemap.xml` if it should be indexed. Redirect aliases, such as `/submit-idea`, should point canonical metadata at the main route to avoid duplicate indexed pages.
+When adding public pages, add route metadata in `src/app/app.ts` and `scripts/generate-route-html.mjs`, then include the canonical page in `public/sitemap.xml` if it should be indexed. Redirect aliases, such as `/submit-idea`, should point canonical metadata at the main route to avoid duplicate indexed pages.
 
 ## Recipe submissions
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ For new food photos:
 - Preserve explicit image dimensions in templates to reduce layout shift.
 - Lazy-load non-hero gallery images and reserve `fetchpriority="high"` for the primary hero image only.
 
+## SEO and metadata
+
+The Angular app updates page titles, meta descriptions, canonical URLs, Open Graph tags, and Twitter/X card tags when primary routes change. Keep canonical metadata pointed at the apex domain, `https://drakesfood.com`, and use the default food photo preview image unless a future route has a stronger route-specific image.
+
+When adding public pages, add route metadata in `src/app/app.ts` and include the canonical page in `public/sitemap.xml` if it should be indexed. Redirect aliases, such as `/submit-idea`, should point canonical metadata at the main route to avoid duplicate indexed pages.
+
 ## Recipe submissions
 
 The V1 recipe submission system is documented in `docs/recipe-submission-system.md`. The detailed API contract is documented in `docs/recipe-submission-api.md`.

--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -49,10 +49,11 @@
 - [x] Build a full gallery page with reusable food cards — #56
 - [x] Add image optimization and responsive image guidelines — #57
 - [x] Redesign homepage hero and primary calls-to-action — #55
+- [x] Add dedicated RecipeSensei teaser page — #59
 
 ## 🔄 In Progress
 
-- [ ] No active issue-scoped work after #55 validation
+- [ ] Expand SEO, social sharing, sitemap, and robots metadata — #58
 
 ## 📋 Remaining Tasks
 
@@ -60,10 +61,10 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 
 ### Content & Visuals
 
-- [ ] Finalize copy for all sections — #15
+- [ ] Review site copy and wording after page breakout — #73
 - [x] Add more gallery images or full gallery page — #19 / #56
 - [x] Add RecipeSensei launch details once available — #21
-- [ ] Refine About section content — #16
+- [ ] Add dedicated About page with social and contact links — #60
 - [ ] Add optional recipe/blog details page later — #22
 
 ### Deployment & Infrastructure

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build && node scripts/generate-route-html.mjs",
     "watch": "ng build --watch --configuration development",
     "lint": "ng lint",
     "test": "echo \"No test runner configured yet. Add Angular test support later.\"",

--- a/scripts/generate-route-html.mjs
+++ b/scripts/generate-route-html.mjs
@@ -1,0 +1,95 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const siteUrl = 'https://drakesfood.com';
+const defaultImageUrl = `${siteUrl}/assets/images/markaritaOoniPizza.jpeg`;
+const defaultImageAlt = 'Margarita pizza fresh from the Ooni oven with melted mozzarella and basil';
+const outputRoot = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist', 'drakesfood-app', 'browser');
+
+const pageMetadata = {
+  '/gallery': {
+    title: "Food Gallery | Drake's Food",
+    description: "Browse Drake's Food photos, including smoked meats, backyard pizza, family meals, and home-cooking experiments.",
+    canonicalPath: '/gallery',
+  },
+  '/recipes': {
+    title: "Recipes & Stories | Drake's Food",
+    description: "Follow future Drake's Food recipes, kitchen notes, food experiments, family favorites, and cooking stories.",
+    canonicalPath: '/recipes',
+  },
+  '/submit': {
+    title: "Submit a Recipe Idea | Drake's Food",
+    description: "Send Drake a recipe idea, family dish, cooking challenge, or food link for possible future Drake's Food inspiration.",
+    canonicalPath: '/submit',
+  },
+  '/submit-idea': {
+    title: "Submit a Recipe Idea | Drake's Food",
+    description: "Send Drake a recipe idea, family dish, cooking challenge, or food link for possible future Drake's Food inspiration.",
+    canonicalPath: '/submit',
+  },
+  '/recipesensei': {
+    title: "RecipeSensei | Drake's Food",
+    description: "RecipeSensei is Drake's recipe-saving and cooking companion app, available for iPhone and iPad on the App Store.",
+    canonicalPath: '/recipesensei',
+  },
+  '/about': {
+    title: "About | Drake's Food",
+    description: "Learn about Drake's Food, a personal, photo-forward home for cooking, food photography, Instagram updates, and RecipeSensei.",
+    canonicalPath: '/about',
+  },
+  '/recipesensei/support': {
+    title: "RecipeSensei Support | Drake's Food",
+    description: "Get support information for RecipeSensei, Drake's recipe-saving and cooking companion app.",
+    canonicalPath: '/recipesensei/support',
+  },
+  '/recipesensei/privacy': {
+    title: "RecipeSensei Privacy Policy | Drake's Food",
+    description: "Review the privacy policy for RecipeSensei, Drake's recipe-saving and cooking companion app.",
+    canonicalPath: '/recipesensei/privacy',
+  },
+};
+
+const indexHtml = await readFile(join(outputRoot, 'index.html'), 'utf8');
+
+await Promise.all(
+  Object.entries(pageMetadata).map(async ([routePath, metadata]) => {
+    const routeHtml = applyMetadata(indexHtml, metadata);
+    const routeIndexPath = join(outputRoot, routePath.slice(1), 'index.html');
+
+    await mkdir(dirname(routeIndexPath), { recursive: true });
+    await writeFile(routeIndexPath, routeHtml);
+  }),
+);
+
+console.log(`Generated route metadata HTML for ${Object.keys(pageMetadata).length} routes.`);
+
+function applyMetadata(html, metadata) {
+  const canonicalUrl = `${siteUrl}${metadata.canonicalPath}`;
+
+  return html
+    .replace(/<title>.*?<\/title>/, `<title>${escapeHtml(metadata.title)}</title>`)
+    .replace(/<meta name="description" content="[^"]*">/, metaName('description', metadata.description))
+    .replace(/<link rel="canonical" href="[^"]*">/, `<link rel="canonical" href="${escapeHtml(canonicalUrl)}">`)
+    .replace(/<meta property="og:title" content="[^"]*">/, metaProperty('og:title', metadata.title))
+    .replace(/<meta property="og:description" content="[^"]*">/, metaProperty('og:description', metadata.description))
+    .replace(/<meta property="og:url" content="[^"]*">/, metaProperty('og:url', canonicalUrl))
+    .replace(/<meta property="og:image" content="[^"]*">/, metaProperty('og:image', defaultImageUrl))
+    .replace(/<meta property="og:image:alt" content="[^"]*">/, metaProperty('og:image:alt', defaultImageAlt))
+    .replace(/<meta name="twitter:title" content="[^"]*">/, metaName('twitter:title', metadata.title))
+    .replace(/<meta name="twitter:description" content="[^"]*">/, metaName('twitter:description', metadata.description))
+    .replace(/<meta name="twitter:image" content="[^"]*">/, metaName('twitter:image', defaultImageUrl))
+    .replace(/<meta name="twitter:image:alt" content="[^"]*">/, metaName('twitter:image:alt', defaultImageAlt));
+}
+
+function metaName(name, content) {
+  return `<meta name="${name}" content="${escapeHtml(content)}">`;
+}
+
+function metaProperty(property, content) {
+  return `<meta property="${property}" content="${escapeHtml(content)}">`;
+}
+
+function escapeHtml(value) {
+  return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -9,7 +9,6 @@
       <a routerLink="/" routerLinkActive="active-link" [routerLinkActiveOptions]="{ exact: true }">Home</a>
       <a routerLink="/gallery" routerLinkActive="active-link">Gallery</a>
       <a routerLink="/recipes" routerLinkActive="active-link">Recipes</a>
-      <a routerLink="/submit" routerLinkActive="active-link">Submit Idea</a>
       <a routerLink="/recipesensei" routerLinkActive="active-link" [routerLinkActiveOptions]="{ exact: true }">RecipeSensei</a>
       <a routerLink="/about" routerLinkActive="active-link">About</a>
     </nav>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,6 +13,7 @@ export const routes: Routes = [
   { path: 'gallery', component: GalleryPageComponent },
   { path: 'recipes', component: RecipesPageComponent },
   { path: 'submit', component: SubmitPageComponent },
+  { path: 'submit-idea', redirectTo: 'submit', pathMatch: 'full' },
   { path: 'recipesensei', component: RecipeSenseiPageComponent },
   { path: 'recipesensei/support', component: RecipeSenseiSupportPageComponent },
   { path: 'recipesensei/privacy', component: RecipeSenseiPrivacyPageComponent },

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,6 +1,64 @@
-import { Component } from '@angular/core';
-import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { DOCUMENT } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Meta, Title } from '@angular/platform-browser';
+import { NavigationEnd, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { filter } from 'rxjs';
 import { FooterComponent } from './components/footer/footer.component';
+
+const SITE_URL = 'https://drakesfood.com';
+const DEFAULT_IMAGE_URL = `${SITE_URL}/assets/images/markaritaOoniPizza.jpeg`;
+const DEFAULT_IMAGE_ALT = 'Margarita pizza fresh from the Ooni oven with melted mozzarella and basil';
+
+interface PageMetadata {
+  title: string;
+  description: string;
+  canonicalPath: string;
+}
+
+const PAGE_METADATA: Record<string, PageMetadata> = {
+  '/': {
+    title: "Drake's Food | Food Photography & Home Cooking",
+    description:
+      "Drake's Food is a warm, photo-first home for food photography, home cooking, Instagram updates, and RecipeSensei inspiration.",
+    canonicalPath: '/',
+  },
+  '/gallery': {
+    title: "Food Gallery | Drake's Food",
+    description: "Browse Drake's Food photos, including smoked meats, backyard pizza, family meals, and home-cooking experiments.",
+    canonicalPath: '/gallery',
+  },
+  '/recipes': {
+    title: "Recipes & Stories | Drake's Food",
+    description: "Follow future Drake's Food recipes, kitchen notes, food experiments, family favorites, and cooking stories.",
+    canonicalPath: '/recipes',
+  },
+  '/submit': {
+    title: "Submit a Recipe Idea | Drake's Food",
+    description: "Send Drake a recipe idea, family dish, cooking challenge, or food link for possible future Drake's Food inspiration.",
+    canonicalPath: '/submit',
+  },
+  '/recipesensei': {
+    title: "RecipeSensei | Drake's Food",
+    description: "RecipeSensei is Drake's recipe-saving and cooking companion app, available for iPhone and iPad on the App Store.",
+    canonicalPath: '/recipesensei',
+  },
+  '/about': {
+    title: "About | Drake's Food",
+    description: "Learn about Drake's Food, a personal, photo-forward home for cooking, food photography, Instagram updates, and RecipeSensei.",
+    canonicalPath: '/about',
+  },
+  '/recipesensei/support': {
+    title: "RecipeSensei Support | Drake's Food",
+    description: 'Get support information for RecipeSensei, Drake\'s recipe-saving and cooking companion app.',
+    canonicalPath: '/recipesensei/support',
+  },
+  '/recipesensei/privacy': {
+    title: "RecipeSensei Privacy Policy | Drake's Food",
+    description: 'Review the privacy policy for RecipeSensei, Drake\'s recipe-saving and cooking companion app.',
+    canonicalPath: '/recipesensei/privacy',
+  },
+};
 
 @Component({
   selector: 'app-root',
@@ -9,4 +67,66 @@ import { FooterComponent } from './components/footer/footer.component';
   templateUrl: './app.html',
   styleUrls: ['./app.css'],
 })
-export class App {}
+export class App {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly document = inject(DOCUMENT);
+  private readonly meta = inject(Meta);
+  private readonly router = inject(Router);
+  private readonly title = inject(Title);
+
+  constructor() {
+    this.applyPageMetadata(this.router.url);
+
+    this.router.events
+      .pipe(
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe((event) => this.applyPageMetadata(event.urlAfterRedirects));
+  }
+
+  private applyPageMetadata(url: string): void {
+    const path = this.normalizePath(url);
+    const metadata = PAGE_METADATA[path] ?? PAGE_METADATA['/'];
+    const canonicalUrl = `${SITE_URL}${metadata.canonicalPath}`;
+
+    this.title.setTitle(metadata.title);
+    this.updateMetaTag('name', 'description', metadata.description);
+    this.updateMetaTag('name', 'robots', 'index, follow');
+    this.updateMetaTag('property', 'og:title', metadata.title);
+    this.updateMetaTag('property', 'og:description', metadata.description);
+    this.updateMetaTag('property', 'og:type', 'website');
+    this.updateMetaTag('property', 'og:url', canonicalUrl);
+    this.updateMetaTag('property', 'og:site_name', "Drake's Food");
+    this.updateMetaTag('property', 'og:image', DEFAULT_IMAGE_URL);
+    this.updateMetaTag('property', 'og:image:alt', DEFAULT_IMAGE_ALT);
+    this.updateMetaTag('name', 'twitter:card', 'summary_large_image');
+    this.updateMetaTag('name', 'twitter:title', metadata.title);
+    this.updateMetaTag('name', 'twitter:description', metadata.description);
+    this.updateMetaTag('name', 'twitter:image', DEFAULT_IMAGE_URL);
+    this.updateMetaTag('name', 'twitter:image:alt', DEFAULT_IMAGE_ALT);
+    this.updateCanonicalUrl(canonicalUrl);
+  }
+
+  private normalizePath(url: string): string {
+    const path = url.split('?')[0].split('#')[0].replace(/\/$/, '');
+
+    return path || '/';
+  }
+
+  private updateMetaTag(attributeName: 'name' | 'property', attributeValue: string, content: string): void {
+    this.meta.updateTag({ [attributeName]: attributeValue, content }, `${attributeName}='${attributeValue}'`);
+  }
+
+  private updateCanonicalUrl(canonicalUrl: string): void {
+    let canonicalLink = this.document.querySelector<HTMLLinkElement>("link[rel='canonical']");
+
+    if (!canonicalLink) {
+      canonicalLink = this.document.createElement('link');
+      canonicalLink.rel = 'canonical';
+      this.document.head.appendChild(canonicalLink);
+    }
+
+    canonicalLink.href = canonicalUrl;
+  }
+}

--- a/src/app/components/about/about.component.css
+++ b/src/app/components/about/about.component.css
@@ -17,3 +17,10 @@
   color: var(--color-text-muted);
   line-height: 1.9;
 }
+
+.about-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin-top: 1.5rem;
+}

--- a/src/app/components/about/about.component.html
+++ b/src/app/components/about/about.component.html
@@ -4,4 +4,7 @@
     <h2 id="about-title">Home-cooked food, thoughtfully captured.</h2>
   </div>
   <p>Drake is building a warm, minimal portfolio of food photography and kitchen stories. This first version keeps the focus on the food, the feel, and a simple path to Instagram.</p>
+  <div class="about-actions" aria-label="About Drake's Food links">
+    <a class="button button-secondary" routerLink="/recipesensei">Explore RecipeSensei</a>
+  </div>
 </section>

--- a/src/app/components/about/about.component.ts
+++ b/src/app/components/about/about.component.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-about',
   standalone: true,
+  imports: [RouterLink],
   templateUrl: './about.component.html',
   styleUrls: ['./about.component.css'],
 })

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -3,9 +3,7 @@
   <nav class="footer-links" aria-label="Footer links">
     <a class="footer-link" routerLink="/gallery">Gallery</a>
     <a class="footer-link" routerLink="/recipes">Recipes</a>
-    <a class="footer-link" routerLink="/submit">Submit an Idea</a>
     <a class="footer-link" routerLink="/about">About</a>
-    <a class="footer-link" href="https://instagram.com/drakesfood" target="_blank" rel="noopener noreferrer" aria-label="Visit @drakesfood on Instagram, opens in a new tab">@drakesfood</a>
     <a class="footer-link" href="https://apps.apple.com/us/app/recipesensei/id6759845210" target="_blank" rel="noopener noreferrer" aria-label="Download RecipeSensei on the App Store, opens in a new tab">RecipeSensei App Store</a>
     <a class="footer-link" routerLink="/recipesensei/support">RecipeSensei Support</a>
     <a class="footer-link" routerLink="/recipesensei/privacy">Privacy Policy</a>

--- a/src/app/components/hero/hero.component.html
+++ b/src/app/components/hero/hero.component.html
@@ -9,10 +9,8 @@
     <p class="hero-support">Follow along for food photography, recipe ideas, cooking notes, and updates as RecipeSensei keeps coming together.</p>
     <div class="hero-actions">
       <a class="button button-primary" routerLink="/gallery">View food gallery</a>
-      <a class="button button-secondary" href="https://instagram.com/drakesfood" target="_blank" rel="noopener noreferrer" aria-label="Follow @drakesfood on Instagram, opens in a new tab">Follow @drakesfood</a>
       <a class="button button-secondary" routerLink="/recipesensei">Explore RecipeSensei</a>
     </div>
-    <p class="hero-note">Have an idea for what I should cook next? <a routerLink="/submit">Send it my way</a>.</p>
   </div>
   <div class="hero-image">
     <img src="assets/images/markaritaOoniPizza.jpeg" alt="Margarita pizza fresh from the Ooni oven with melted mozzarella and basil" width="1280" height="1600" fetchpriority="high" decoding="async" />

--- a/src/app/components/recipe-blog/recipe-blog.component.html
+++ b/src/app/components/recipe-blog/recipe-blog.component.html
@@ -11,13 +11,11 @@
   </div>
   @if (variant === 'page') {
     <p>The collection of recipes and food writing will grow here once the kitchen notes are ready to share. Expect home-cooking notes, experiments, family favorites, and the occasional smoked meat deep dive.</p>
-    <p>Have something Drake should cook? Send a recipe idea from the submit page.</p>
-    <a class="button button-primary" routerLink="/submit">Submit a recipe idea</a>
+    <p>Have something Drake should cook? The homepage has the current submission path while the recipes section is still getting built out.</p>
   } @else {
-    <p>Recipes and cooking notes are coming soon. Head to the recipe page for updates as posts start landing, or send an idea for what Drake should cook next.</p>
+    <p>Recipes and cooking notes are coming soon. Head to the recipe page for updates as posts start landing.</p>
     <div class="recipe-blog-actions">
       <a class="button button-primary" routerLink="/recipes">Visit recipes</a>
-      <a class="button button-secondary" routerLink="/submit">Submit a recipe idea</a>
     </div>
   }
 </section>

--- a/src/app/pages/home-page/home-page.component.html
+++ b/src/app/pages/home-page/home-page.component.html
@@ -1,7 +1,6 @@
 <app-hero></app-hero>
 <app-gallery-preview></app-gallery-preview>
 <app-instagram-cta></app-instagram-cta>
-<app-about></app-about>
 <app-recipe-sensei></app-recipe-sensei>
 <app-submit-idea-cta></app-submit-idea-cta>
 <app-recipe-blog variant="teaser"></app-recipe-blog>

--- a/src/app/pages/home-page/home-page.component.ts
+++ b/src/app/pages/home-page/home-page.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { AboutComponent } from '../../components/about/about.component';
 import { GalleryPreviewComponent } from '../../components/gallery-preview/gallery-preview.component';
 import { HeroComponent } from '../../components/hero/hero.component';
 import { InstagramCtaComponent } from '../../components/instagram-cta/instagram-cta.component';
@@ -14,7 +13,6 @@ import { SubmitIdeaCtaComponent } from '../../components/submit-idea-cta/submit-
     HeroComponent,
     GalleryPreviewComponent,
     InstagramCtaComponent,
-    AboutComponent,
     RecipeSenseiComponent,
     SubmitIdeaCtaComponent,
     RecipeBlogComponent,

--- a/src/index.html
+++ b/src/index.html
@@ -16,6 +16,8 @@
   <meta property="og:site_name" content="Drake's Food">
   <meta property="og:image" content="https://drakesfood.com/assets/images/markaritaOoniPizza.jpeg">
   <meta property="og:image:alt" content="Margarita pizza fresh from the Ooni oven with melted mozzarella and basil">
+  <meta property="og:image:width" content="1280">
+  <meta property="og:image:height" content="960">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Drake's Food | Food Photography & Home Cooking">

--- a/src/styles.css
+++ b/src/styles.css
@@ -102,9 +102,14 @@ button,
 }
 
 .button-secondary {
-  background: var(--color-purple-dark);
-  color: #fff;
+  border: 1px solid rgba(61, 37, 111, 0.28);
+  background: rgba(255, 250, 245, 0.74);
+  color: var(--color-purple-dark);
   padding: 1.5rem 2.5rem;
+}
+
+.button-secondary:hover {
+  background: rgba(109, 74, 163, 0.1);
 }
 
 p {


### PR DESCRIPTION
## Summary
- Add route-aware titles, descriptions, canonicals, Open Graph, and Twitter/X metadata for the primary Angular routes.
- Add `/submit-idea` as an alias to the existing submit page and document SEO metadata conventions.
- Simplify homepage CTA pathways so Instagram and submit idea each have one primary homepage path, remove duplicate About content from home, and make secondary buttons visually secondary.

Closes #58
Closes #61
Refs #60
Refs #73

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Visual Review
- Not run in browser during this pass. Changes were reviewed structurally and validated with lint/typecheck/build.

## Notes
- RecipeSensei is live, so route metadata and page copy describe App Store availability.
- About page intentionally does not include a separate Instagram CTA now that the homepage has a single dedicated Instagram pathway.