### PR TITLE
Fix router scroll restoration

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,11 +1,17 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { provideRouter, withInMemoryScrolling } from '@angular/router';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes)
-  ]
+    provideRouter(
+      routes,
+      withInMemoryScrolling({
+        anchorScrolling: 'enabled',
+        scrollPositionRestoration: 'enabled',
+      }),
+    ),
+  ],
 };


### PR DESCRIPTION
## Summary
- Enables Angular in-memory router scrolling so internal page navigation starts at the top.
- Preserves browser back/forward scroll restoration and anchor scrolling.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test` (configured script currently reports no test runner)

## Notes
- Fixes the behavior where clicking a site link from the bottom of one page opens the next route near the bottom.