### PR TITLE
Add blog email subscription signup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ env:
   S3_BUCKET: drakesfood.com
   CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
   RECIPE_SUBMISSIONS_API_BASE_URL: ${{ vars.RECIPE_SUBMISSIONS_API_BASE_URL }}
+  BLOG_SUBSCRIPTIONS_API_BASE_URL: ${{ vars.BLOG_SUBSCRIPTIONS_API_BASE_URL }}
 
 jobs:
   deploy:
@@ -43,7 +44,7 @@ jobs:
 
       - name: Write runtime app config
         run: |
-          node -e 'const fs = require("node:fs"); const config = { recipeSubmissionsApiBaseUrl: process.env.RECIPE_SUBMISSIONS_API_BASE_URL || "" }; fs.writeFileSync("dist/drakesfood-app/browser/app-config.json", JSON.stringify(config, null, 2) + "\n");'
+          node -e 'const fs = require("node:fs"); const config = { recipeSubmissionsApiBaseUrl: process.env.RECIPE_SUBMISSIONS_API_BASE_URL || "", blogSubscriptionsApiBaseUrl: process.env.BLOG_SUBSCRIPTIONS_API_BASE_URL || "" }; fs.writeFileSync("dist/drakesfood-app/browser/app-config.json", JSON.stringify(config, null, 2) + "\n");'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ When adding public pages, add route metadata in `src/app/app.ts` and `scripts/ge
 
 The V1 recipe submission system is documented in `docs/recipe-submission-system.md`. The detailed API contract is documented in `docs/recipe-submission-api.md`.
 
+## Blog email subscriptions
+
+The V1 blog email subscription signup and confirmation system is documented in `docs/blog-email-subscriptions.md`. It uses confirmed opt-in before activating subscribers. Unsubscribe support and new-post notification sending are tracked separately.
+
 ## Deployment
 
 The site deploys built Angular assets to the existing `drakesfood.com` S3 bucket through GitHub Actions. HTTPS is handled by CloudFront with an ACM certificate and Route 53 records managed by OpenTofu in `infra/`.

--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -55,6 +55,7 @@
 ## 🔄 In Progress
 
 - [ ] Expand SEO, social sharing, sitemap, and robots metadata — #58
+- [ ] Add blog email signup form and confirmed subscriptions — #82
 
 ## 📋 Remaining Tasks
 
@@ -133,6 +134,7 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - Issue #19 was closed as stale because the full gallery page work landed through #56; image follow-up landed through #57.
 - Homepage hero now leads with a clearer Drake's Food introduction, stronger gallery/Instagram/RecipeSensei CTAs, and a lighter submit-idea prompt.
 - Blog now includes a featured story layout and the first full post, `The One Day a Year I Bake`, with process photos and a RecipeSensei import link.
+- Blog email subscription signup and confirmed opt-in are being added with a dedicated Angular form, runtime API config, API Gateway, Lambda, DynamoDB, and SES confirmation emails.
 
 ## Last Updated
 

--- a/docs/blog-email-subscriptions.md
+++ b/docs/blog-email-subscriptions.md
@@ -88,7 +88,7 @@ The DynamoDB table is created by `aws_dynamodb_table.blog_subscribers`.
 
 Default table name: `drakesfood-blog-subscribers`
 
-The table uses pay-per-request billing and is keyed by `subscriberId`. It includes GSIs for `emailHash` and `confirmationTokenHash` lookups.
+The table uses pay-per-request billing and is keyed by `emailHash` so each normalized email can have only one subscriber record. It includes a GSI for `confirmationTokenHash` lookups.
 
 Subscriber item shape:
 
@@ -107,7 +107,7 @@ Subscriber item shape:
 }
 ```
 
-`confirmedAt` appears after confirmation. `confirmationTokenHash` is removed after successful confirmation. `unsubscribeTokenHash` is stored now so #83 can add unsubscribe support without changing the subscriber creation flow.
+`subscriberId` is a stored identifier for logging and debugging, not the table key. `confirmedAt` appears after confirmation. `confirmationTokenHash` is removed after successful confirmation. `unsubscribeTokenHash` is stored now so #83 can add unsubscribe support without changing the subscriber creation flow.
 
 ## Privacy
 

--- a/docs/blog-email-subscriptions.md
+++ b/docs/blog-email-subscriptions.md
@@ -1,0 +1,207 @@
+# Blog Email Subscriptions
+
+This document explains the V1 blog email subscription system for `drakesfood.com`. The feature lets readers request email notifications for new Drake's Food blog posts.
+
+V1 is intentionally small:
+
+- Readers submit only an email address.
+- Readers must confirm before becoming active subscribers.
+- Subscriber emails are private operational data.
+- New-post notification sending and unsubscribe handling are tracked separately in #84 and #83.
+
+## Frontend
+
+The Angular signup form lives in:
+
+- `src/app/components/blog-subscription/blog-subscription.component.ts`
+- `src/app/components/blog-subscription/blog-subscription.component.html`
+- `src/app/components/blog-subscription/blog-subscription.component.css`
+
+The component is rendered inside the blog section from `src/app/components/recipe-blog/recipe-blog.component.html`.
+
+The frontend posts through `src/app/services/blog-subscription-api.service.ts`. It reads the API base URL from `AppConfigService`, which fetches `/app-config.json` at runtime. Local development starts with `public/app-config.json` configured as:
+
+```json
+{
+  "recipeSubmissionsApiBaseUrl": "",
+  "blogSubscriptionsApiBaseUrl": ""
+}
+```
+
+When the value is blank, the form stays visible but reports that email updates are not connected yet. In production, GitHub Actions writes `dist/drakesfood-app/browser/app-config.json` using the repository variable `BLOG_SUBSCRIPTIONS_API_BASE_URL`.
+
+## API
+
+Signup endpoint:
+
+```http
+POST /blog-subscriptions
+Content-Type: application/json
+```
+
+Request body:
+
+```json
+{
+  "email": "reader@example.com",
+  "website": ""
+}
+```
+
+The `website` field is a honeypot. Valid readers should leave it blank.
+
+Success response:
+
+```json
+{
+  "success": true,
+  "message": "If that email can be subscribed, a confirmation link is on the way."
+}
+```
+
+The success response is intentionally generic so the API does not reveal whether an email is already subscribed.
+
+Confirmation endpoint:
+
+```http
+GET /blog-subscriptions/confirm?token=<confirmation-token>
+```
+
+Valid confirmation tokens activate the pending subscriber and redirect to `/blog?subscription=confirmed`. Invalid or expired tokens redirect to `/blog?subscription=invalid`.
+
+## Backend Resources
+
+Blog subscription infrastructure is defined in `infra/blog_subscriptions.tf`.
+
+The V1 architecture uses:
+
+- API Gateway HTTP API for `POST /blog-subscriptions` and `GET /blog-subscriptions/confirm`.
+- Lambda for validation, honeypot handling, DynamoDB writes, SES confirmation emails, and confirmation activation.
+- DynamoDB for subscriber records.
+- SES for confirmation emails.
+- CloudWatch Logs for API Gateway access logs and Lambda logs.
+- OpenTofu for resource management.
+
+## DynamoDB
+
+The DynamoDB table is created by `aws_dynamodb_table.blog_subscribers`.
+
+Default table name: `drakesfood-blog-subscribers`
+
+The table uses pay-per-request billing and is keyed by `subscriberId`. It includes GSIs for `emailHash` and `confirmationTokenHash` lookups.
+
+Subscriber item shape:
+
+```json
+{
+  "subscriberId": "uuid",
+  "emailNormalized": "reader@example.com",
+  "emailHash": "sha256 hash",
+  "status": "pending",
+  "createdAt": "2026-05-09T12:00:00.000Z",
+  "updatedAt": "2026-05-09T12:00:00.000Z",
+  "confirmedAt": "2026-05-09T12:05:00.000Z",
+  "confirmationTokenHash": "sha256 hash",
+  "unsubscribeTokenHash": "sha256 hash",
+  "source": "drakesfood.com"
+}
+```
+
+`confirmedAt` appears after confirmation. `confirmationTokenHash` is removed after successful confirmation. `unsubscribeTokenHash` is stored now so #83 can add unsubscribe support without changing the subscriber creation flow.
+
+## Privacy
+
+Subscriber email addresses are private data.
+
+- Do not commit subscriber exports.
+- Do not add subscriber emails to GitHub issues, logs, screenshots, or docs.
+- Prefer logging `subscriberId` and error names instead of raw email addresses.
+- Tokens are stored as SHA-256 hashes, not raw token values.
+
+## SES
+
+SES sends confirmation emails from the configured sender.
+
+Before production confirmations can work:
+
+- Verify `drakesfood.com` as an SES sending identity, or provide a specific verified identity ARN.
+- If the AWS account is still in the SES sandbox, verified recipient limitations will apply.
+- Set `blog_subscriptions_ses_sender_email` through a local `.tfvars` file or `-var` argument.
+- Set `blog_subscriptions_ses_identity_arn` only if the sending identity is not the default `drakesfood.com` domain identity in the active AWS account.
+
+Recommended sender:
+
+```txt
+Drake's Food <updates@drakesfood.com>
+```
+
+A real mailbox for `updates@drakesfood.com` is not required for V1 sending, but forwarding is recommended later if reader replies should land somewhere useful.
+
+## OpenTofu Deployment
+
+Useful variables for this feature are defined in `infra/variables.tf`:
+
+- `blog_subscriptions_api_name`
+- `blog_subscriptions_allowed_origins`
+- `blog_subscriptions_lambda_function_name`
+- `blog_subscriptions_log_retention_days`
+- `blog_subscriptions_max_body_bytes`
+- `blog_subscriptions_ses_identity_arn`
+- `blog_subscriptions_ses_sender_email`
+- `blog_subscriptions_source_site`
+- `blog_subscriptions_table_name`
+- `blog_subscriptions_throttling_burst_limit`
+- `blog_subscriptions_throttling_rate_limit`
+
+Preview and apply from `infra/` with the AWS profile selected:
+
+```bash
+AWS_PROFILE=drakesfood tofu plan
+AWS_PROFILE=drakesfood tofu apply
+```
+
+After apply, get the values needed for frontend configuration and operational checks:
+
+```bash
+AWS_PROFILE=drakesfood tofu output -raw blog_subscriptions_api_endpoint
+AWS_PROFILE=drakesfood tofu output -raw blog_subscriptions_table_name
+AWS_PROFILE=drakesfood tofu output -raw blog_subscriptions_lambda_function_name
+```
+
+## GitHub Actions Deployment
+
+The static site deploy workflow is `.github/workflows/deploy.yml`. It runs on pushes to `main`.
+
+Required GitHub repository variable:
+
+- `BLOG_SUBSCRIPTIONS_API_BASE_URL`: set to the OpenTofu output `blog_subscriptions_api_endpoint`.
+
+Related deployment requirements:
+
+- `AWS_ACCESS_KEY_ID` repository secret
+- `AWS_SECRET_ACCESS_KEY` repository secret
+- `CLOUDFRONT_DISTRIBUTION_ID` repository variable for cache invalidation
+
+If `BLOG_SUBSCRIPTIONS_API_BASE_URL` is missing or blank, production will deploy successfully but the public signup form will use its not-connected-yet fallback.
+
+## Local Testing
+
+Run the standard app checks from the repository root:
+
+```bash
+npm run lint
+npm run typecheck
+npm run build
+```
+
+Run the Lambda tests:
+
+```bash
+node --test infra/lambda/blog-subscriptions/index.test.mjs
+```
+
+## Follow-Up Work
+
+- #83 adds unsubscribe support.
+- #84 sends new-post notifications to active subscribers.
+- #85 expands operating documentation after the full notification flow exists.

--- a/infra/README.md
+++ b/infra/README.md
@@ -14,6 +14,10 @@ OpenTofu manages the AWS resources needed to serve `drakesfood.com` over HTTPS.
 - Lambda function, execution role, and CloudWatch logs for recipe submissions
 - DynamoDB table for recipe submission storage
 - SES send permissions for recipe submission notifications
+- API Gateway HTTP API for blog email subscription signup and confirmation
+- Lambda function, execution role, and CloudWatch logs for blog email subscriptions
+- DynamoDB table for blog email subscriber storage
+- SES send permissions for blog subscription confirmation emails
 
 CloudFront requires ACM certificates to be in `us-east-1`, so this config uses a secondary AWS provider for the certificate while keeping the existing S3 bucket in `us-east-2`.
 
@@ -34,6 +38,39 @@ The Lambda source lives at `lambda/recipe-submissions/index.mjs`. It validates s
 The Lambda request body limit defaults to `16384` bytes and can be adjusted with `recipe_submissions_max_body_bytes` if the text-only V1 form needs more room later. V1 intentionally does not include CAPTCHA; add it only if real abuse requires the extra friction.
 
 See `../docs/recipe-submission-system.md` for the end-to-end recipe submission system documentation, including frontend wiring, API behavior, deployment, testing, and CloudWatch log locations.
+
+## Blog Email Subscriptions
+
+The blog subscription backend is defined as low-cost serverless infrastructure:
+
+- API Gateway HTTP API exposes `POST /blog-subscriptions` and `GET /blog-subscriptions/confirm`.
+- CORS is restricted to `drakesfood.com`, `www.drakesfood.com`, and local Angular development by default.
+- Lambda receives the table name, source site, allowed origins, API base URL, site URL, and SES sender through environment variables.
+- DynamoDB stores subscriber records by `subscriberId` with lookup indexes for email hashes and confirmation token hashes.
+- SES sends a plain-text confirmation email after a valid signup is stored.
+- CloudWatch log groups use the configured retention period.
+- API Gateway throttling defaults to 10 burst requests and 5 sustained requests per second.
+
+The Lambda source lives at `lambda/blog-subscriptions/index.mjs`. It validates signup requests, handles honeypot submissions without storing or emailing them, stores pending subscribers in DynamoDB, sends SES confirmation emails when a sender is configured, and activates pending subscribers from confirmation links.
+
+The Lambda request body limit defaults to `8192` bytes and can be adjusted with `blog_subscriptions_max_body_bytes` if needed.
+
+See `../docs/blog-email-subscriptions.md` for the end-to-end blog subscription documentation, including frontend wiring, API behavior, deployment, testing, privacy notes, and follow-up work.
+
+Before applying blog subscription infrastructure for production, set these values with a local `.tfvars` file or `-var` arguments. The SES identity ARN can be omitted if the verified identity is the site domain in the active AWS account.
+
+```hcl
+blog_subscriptions_ses_identity_arn = "arn:aws:ses:us-east-2:<account-id>:identity/drakesfood.com"
+blog_subscriptions_ses_sender_email = "Drake's Food <updates@drakesfood.com>"
+```
+
+Do not commit real private email addresses or account-specific values unless they are intentionally public. The SES sender identity must be verified before confirmation emails can work. If the SES sender is missing, accepted signups are still stored but confirmation email is skipped and logged.
+
+After apply, get the API endpoint for frontend configuration:
+
+```bash
+AWS_PROFILE=drakesfood tofu output -raw blog_subscriptions_api_endpoint
+```
 
 Before applying recipe submission infrastructure for production, set these values with a local `.tfvars` file or `-var` arguments. The SES identity ARN can be omitted if the verified identity is the site domain in the active AWS account.
 
@@ -107,6 +144,7 @@ After apply finishes, get the CloudFront distribution ID and recipe submission A
 ```bash
 AWS_PROFILE=drakesfood tofu output -raw cloudfront_distribution_id
 AWS_PROFILE=drakesfood tofu output -raw recipe_submissions_api_endpoint
+AWS_PROFILE=drakesfood tofu output -raw blog_subscriptions_api_endpoint
 ```
 
 Add that value as a GitHub repository variable named `CLOUDFRONT_DISTRIBUTION_ID`.
@@ -122,8 +160,11 @@ It also needs these GitHub repository variables:
 
 - `CLOUDFRONT_DISTRIBUTION_ID`
 - `RECIPE_SUBMISSIONS_API_BASE_URL`
+- `BLOG_SUBSCRIPTIONS_API_BASE_URL`
 
 Set `RECIPE_SUBMISSIONS_API_BASE_URL` to the `recipe_submissions_api_endpoint` OpenTofu output after the recipe submission infrastructure is applied. The deploy workflow writes this value into `app-config.json` at deploy time. Until it is configured, the public form keeps its not-connected-yet fallback.
+
+Set `BLOG_SUBSCRIPTIONS_API_BASE_URL` to the `blog_subscriptions_api_endpoint` OpenTofu output after the blog subscription infrastructure is applied. Until it is configured, the public signup form keeps its not-connected-yet fallback.
 
 The AWS credentials must be allowed to sync files to the S3 bucket and create CloudFront invalidations. Until `CLOUDFRONT_DISTRIBUTION_ID` is configured, the deploy workflow will still sync to S3 but will skip CloudFront invalidation.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -46,7 +46,7 @@ The blog subscription backend is defined as low-cost serverless infrastructure:
 - API Gateway HTTP API exposes `POST /blog-subscriptions` and `GET /blog-subscriptions/confirm`.
 - CORS is restricted to `drakesfood.com`, `www.drakesfood.com`, and local Angular development by default.
 - Lambda receives the table name, source site, allowed origins, API base URL, site URL, and SES sender through environment variables.
-- DynamoDB stores subscriber records by `subscriberId` with lookup indexes for email hashes and confirmation token hashes.
+- DynamoDB stores subscriber records by `emailHash` so each normalized email has one record, with a lookup index for confirmation token hashes.
 - SES sends a plain-text confirmation email after a valid signup is stored.
 - CloudWatch log groups use the configured retention period.
 - API Gateway throttling defaults to 10 burst requests and 5 sustained requests per second.

--- a/infra/blog_subscriptions.tf
+++ b/infra/blog_subscriptions.tf
@@ -1,0 +1,219 @@
+locals {
+  blog_subscriptions_ses_identity_arn = var.blog_subscriptions_ses_identity_arn != "" ? var.blog_subscriptions_ses_identity_arn : "arn:aws:ses:${var.aws_region}:${data.aws_caller_identity.current.account_id}:identity/${var.domain_name}"
+}
+
+resource "aws_dynamodb_table" "blog_subscribers" {
+  name         = var.blog_subscriptions_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "subscriberId"
+
+  attribute {
+    name = "subscriberId"
+    type = "S"
+  }
+
+  attribute {
+    name = "emailHash"
+    type = "S"
+  }
+
+  attribute {
+    name = "confirmationTokenHash"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "emailHash-index"
+    hash_key        = "emailHash"
+    projection_type = "ALL"
+  }
+
+  global_secondary_index {
+    name            = "confirmationTokenHash-index"
+    hash_key        = "confirmationTokenHash"
+    projection_type = "ALL"
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+}
+
+resource "aws_cloudwatch_log_group" "blog_subscriptions_lambda" {
+  name              = "/aws/lambda/${var.blog_subscriptions_lambda_function_name}"
+  retention_in_days = var.blog_subscriptions_log_retention_days
+}
+
+resource "aws_cloudwatch_log_group" "blog_subscriptions_api" {
+  name              = "/aws/apigateway/${var.blog_subscriptions_api_name}"
+  retention_in_days = var.blog_subscriptions_log_retention_days
+}
+
+data "aws_iam_policy_document" "blog_subscriptions_lambda_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "blog_subscriptions_lambda" {
+  name               = "${var.blog_subscriptions_lambda_function_name}-role"
+  assume_role_policy = data.aws_iam_policy_document.blog_subscriptions_lambda_assume_role.json
+}
+
+data "aws_iam_policy_document" "blog_subscriptions_lambda" {
+  statement {
+    sid = "WriteBlogSubscribers"
+
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+    ]
+
+    resources = [
+      aws_dynamodb_table.blog_subscribers.arn,
+    ]
+  }
+
+  statement {
+    sid = "QueryBlogSubscriberIndexes"
+
+    actions = [
+      "dynamodb:Query",
+    ]
+
+    resources = [
+      "${aws_dynamodb_table.blog_subscribers.arn}/index/*",
+    ]
+  }
+
+  statement {
+    sid = "SendBlogSubscriptionEmail"
+
+    actions = [
+      "ses:SendEmail",
+      "ses:SendRawEmail",
+    ]
+
+    resources = [local.blog_subscriptions_ses_identity_arn]
+  }
+
+  statement {
+    sid = "WriteLambdaLogs"
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.blog_subscriptions_lambda.arn}:*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "blog_subscriptions_lambda" {
+  name   = "${var.blog_subscriptions_lambda_function_name}-policy"
+  role   = aws_iam_role.blog_subscriptions_lambda.id
+  policy = data.aws_iam_policy_document.blog_subscriptions_lambda.json
+}
+
+data "archive_file" "blog_subscriptions_lambda" {
+  type        = "zip"
+  source_file = "${path.module}/lambda/blog-subscriptions/index.mjs"
+  output_path = "${path.module}/.terraform/blog-subscriptions-lambda.zip"
+}
+
+resource "aws_lambda_function" "blog_subscriptions" {
+  function_name    = var.blog_subscriptions_lambda_function_name
+  description      = "Handles Drake's Food blog email subscriptions."
+  filename         = data.archive_file.blog_subscriptions_lambda.output_path
+  source_code_hash = data.archive_file.blog_subscriptions_lambda.output_base64sha256
+  handler          = "index.handler"
+  runtime          = "nodejs22.x"
+  role             = aws_iam_role.blog_subscriptions_lambda.arn
+  timeout          = 10
+  memory_size      = 128
+
+  environment {
+    variables = {
+      ALLOWED_ORIGINS                   = join(",", var.blog_subscriptions_allowed_origins)
+      BLOG_SUBSCRIPTIONS_API_BASE_URL   = aws_apigatewayv2_api.blog_subscriptions.api_endpoint
+      BLOG_SUBSCRIPTIONS_MAX_BODY_BYTES = tostring(var.blog_subscriptions_max_body_bytes)
+      BLOG_SUBSCRIPTIONS_SITE_URL       = "https://${var.domain_name}"
+      BLOG_SUBSCRIPTIONS_SOURCE_SITE    = var.blog_subscriptions_source_site
+      BLOG_SUBSCRIPTIONS_TABLE_NAME     = aws_dynamodb_table.blog_subscribers.name
+      SES_SENDER_EMAIL                  = var.blog_subscriptions_ses_sender_email
+    }
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.blog_subscriptions_lambda,
+    aws_iam_role_policy.blog_subscriptions_lambda,
+  ]
+}
+
+resource "aws_apigatewayv2_api" "blog_subscriptions" {
+  name          = var.blog_subscriptions_api_name
+  protocol_type = "HTTP"
+
+  cors_configuration {
+    allow_headers = ["content-type"]
+    allow_methods = ["GET", "POST", "OPTIONS"]
+    allow_origins = var.blog_subscriptions_allowed_origins
+    max_age       = 3600
+  }
+}
+
+resource "aws_apigatewayv2_integration" "blog_subscriptions" {
+  api_id                 = aws_apigatewayv2_api.blog_subscriptions.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.blog_subscriptions.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "blog_subscriptions_post" {
+  api_id    = aws_apigatewayv2_api.blog_subscriptions.id
+  route_key = "POST /blog-subscriptions"
+  target    = "integrations/${aws_apigatewayv2_integration.blog_subscriptions.id}"
+}
+
+resource "aws_apigatewayv2_route" "blog_subscriptions_confirm_get" {
+  api_id    = aws_apigatewayv2_api.blog_subscriptions.id
+  route_key = "GET /blog-subscriptions/confirm"
+  target    = "integrations/${aws_apigatewayv2_integration.blog_subscriptions.id}"
+}
+
+resource "aws_apigatewayv2_stage" "blog_subscriptions_default" {
+  api_id      = aws_apigatewayv2_api.blog_subscriptions.id
+  name        = "$default"
+  auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.blog_subscriptions_api.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      httpMethod     = "$context.httpMethod"
+      routeKey       = "$context.routeKey"
+      status         = "$context.status"
+      responseLength = "$context.responseLength"
+    })
+  }
+
+  default_route_settings {
+    throttling_burst_limit = var.blog_subscriptions_throttling_burst_limit
+    throttling_rate_limit  = var.blog_subscriptions_throttling_rate_limit
+  }
+}
+
+resource "aws_lambda_permission" "blog_subscriptions_api" {
+  statement_id  = "AllowBlogSubscriptionsApiInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.blog_subscriptions.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.blog_subscriptions.execution_arn}/*/*"
+}

--- a/infra/blog_subscriptions.tf
+++ b/infra/blog_subscriptions.tf
@@ -5,12 +5,7 @@ locals {
 resource "aws_dynamodb_table" "blog_subscribers" {
   name         = var.blog_subscriptions_table_name
   billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "subscriberId"
-
-  attribute {
-    name = "subscriberId"
-    type = "S"
-  }
+  hash_key     = "emailHash"
 
   attribute {
     name = "emailHash"
@@ -20,12 +15,6 @@ resource "aws_dynamodb_table" "blog_subscribers" {
   attribute {
     name = "confirmationTokenHash"
     type = "S"
-  }
-
-  global_secondary_index {
-    name            = "emailHash-index"
-    hash_key        = "emailHash"
-    projection_type = "ALL"
   }
 
   global_secondary_index {
@@ -70,6 +59,7 @@ data "aws_iam_policy_document" "blog_subscriptions_lambda" {
     sid = "WriteBlogSubscribers"
 
     actions = [
+      "dynamodb:GetItem",
       "dynamodb:PutItem",
       "dynamodb:UpdateItem",
     ]

--- a/infra/lambda/blog-subscriptions/index.mjs
+++ b/infra/lambda/blog-subscriptions/index.mjs
@@ -166,7 +166,7 @@ async function confirmSubscription(event, { now, findSubscriberByConfirmationTok
   }
 
   try {
-    await activateSubscriber(subscriber.subscriberId, now().toISOString());
+    await activateSubscriber(subscriber.emailHash, now().toISOString());
   } catch (error) {
     console.error('Failed to confirm blog subscriber.', {
       errorName: error?.name,
@@ -286,23 +286,20 @@ function normalizeSignupBody(body) {
 
 async function findSubscriberByEmailHashInDynamoDb(emailHash) {
   const tableName = getTableName();
-  const { DynamoDBClient, QueryCommand } = await loadDynamoDbClient();
+  const { DynamoDBClient, GetItemCommand } = await loadDynamoDbClient();
   const client = dynamoClient ?? new DynamoDBClient({});
   dynamoClient = client;
 
   const response = await client.send(
-    new QueryCommand({
+    new GetItemCommand({
       TableName: tableName,
-      IndexName: 'emailHash-index',
-      KeyConditionExpression: 'emailHash = :emailHash',
-      ExpressionAttributeValues: {
-        ':emailHash': { S: emailHash },
+      Key: {
+        emailHash: { S: emailHash },
       },
-      Limit: 1,
     }),
   );
 
-  return response.Items?.[0] ? fromDynamoDbItem(response.Items[0]) : undefined;
+  return response.Item ? fromDynamoDbItem(response.Item) : undefined;
 }
 
 async function findSubscriberByConfirmationTokenHashInDynamoDb(confirmationTokenHash) {
@@ -340,7 +337,7 @@ async function savePendingSubscriberToDynamoDb(subscriber) {
   );
 }
 
-async function activateSubscriberInDynamoDb(subscriberId, confirmedAt) {
+async function activateSubscriberInDynamoDb(emailHash, confirmedAt) {
   const tableName = getTableName();
   const { DynamoDBClient, UpdateItemCommand } = await loadDynamoDbClient();
   const client = dynamoClient ?? new DynamoDBClient({});
@@ -350,7 +347,7 @@ async function activateSubscriberInDynamoDb(subscriberId, confirmedAt) {
     new UpdateItemCommand({
       TableName: tableName,
       Key: {
-        subscriberId: { S: subscriberId },
+        emailHash: { S: emailHash },
       },
       UpdateExpression: 'SET #status = :active, confirmedAt = :confirmedAt, updatedAt = :confirmedAt REMOVE confirmationTokenHash',
       ConditionExpression: '#status = :pending',

--- a/infra/lambda/blog-subscriptions/index.mjs
+++ b/infra/lambda/blog-subscriptions/index.mjs
@@ -1,0 +1,500 @@
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+
+const SIGNUP_SUCCESS_MESSAGE = 'If that email can be subscribed, a confirmation link is on the way.';
+const CONFIRMATION_SUCCESS_REDIRECT = '/blog?subscription=confirmed';
+const CONFIRMATION_FAILURE_REDIRECT = '/blog?subscription=invalid';
+const DEFAULT_MAX_BODY_BYTES = 8 * 1024;
+const EMAIL_LIMIT = 254;
+
+let dynamoClient;
+let dynamoModule;
+let sesClient;
+let sesModule;
+
+export const createHandler = ({
+  now = () => new Date(),
+  uuid = randomUUID,
+  createToken = () => randomBytes(32).toString('base64url'),
+  findSubscriberByEmailHash = findSubscriberByEmailHashInDynamoDb,
+  findSubscriberByConfirmationTokenHash = findSubscriberByConfirmationTokenHashInDynamoDb,
+  savePendingSubscriber = savePendingSubscriberToDynamoDb,
+  activateSubscriber = activateSubscriberInDynamoDb,
+  sendConfirmation = sendConfirmationEmail,
+} = {}) => async (event = {}) => {
+  const method = getMethod(event);
+  const path = getPath(event);
+
+  if (method === 'GET' && path.endsWith('/blog-subscriptions/confirm')) {
+    return confirmSubscription(event, { now, findSubscriberByConfirmationTokenHash, activateSubscriber });
+  }
+
+  if (method !== 'POST') {
+    return jsonResponse(405, {
+      success: false,
+      message: 'Blog subscriptions only accept POST requests.',
+    });
+  }
+
+  if (!isAllowedOrigin(event)) {
+    return jsonResponse(403, {
+      success: false,
+      message: 'Blog subscriptions are not available from this origin.',
+    });
+  }
+
+  if (!isJsonContentType(event)) {
+    return jsonResponse(415, {
+      success: false,
+      message: 'Please send blog subscriptions as JSON.',
+    });
+  }
+
+  let body;
+
+  try {
+    body = parseBody(event, getMaxBodyBytes());
+  } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      return jsonResponse(413, {
+        success: false,
+        message: 'Please use a shorter email address and try again.',
+      });
+    }
+
+    return jsonResponse(400, {
+      success: false,
+      message: 'Please send a valid JSON blog subscription.',
+    });
+  }
+
+  const normalized = normalizeSignupBody(body);
+
+  if (!normalized.valid) {
+    return jsonResponse(400, {
+      success: false,
+      message: normalized.message,
+    });
+  }
+
+  if (normalized.values.website) {
+    console.info('Blog subscription ignored by spam filter.');
+
+    return jsonResponse(200, {
+      success: true,
+      message: SIGNUP_SUCCESS_MESSAGE,
+    });
+  }
+
+  const emailHash = hashValue(normalized.values.email);
+  let existingSubscriber;
+
+  try {
+    existingSubscriber = await findExistingSubscriber(emailHash, findSubscriberByEmailHash);
+  } catch {
+    return jsonResponse(500, {
+      success: false,
+      message: 'Blog subscriptions are temporarily unavailable. Please try again later.',
+    });
+  }
+
+  if (existingSubscriber?.status === 'active') {
+    return jsonResponse(200, {
+      success: true,
+      message: SIGNUP_SUCCESS_MESSAGE,
+    });
+  }
+
+  const confirmationToken = createToken();
+  const unsubscribeToken = createToken();
+  const timestamp = now().toISOString();
+  const subscriber = {
+    subscriberId: existingSubscriber?.subscriberId || uuid(),
+    emailNormalized: normalized.values.email,
+    emailHash,
+    status: 'pending',
+    createdAt: existingSubscriber?.createdAt || timestamp,
+    updatedAt: timestamp,
+    confirmationTokenHash: hashValue(confirmationToken),
+    unsubscribeTokenHash: existingSubscriber?.unsubscribeTokenHash || hashValue(unsubscribeToken),
+    source: process.env.BLOG_SUBSCRIPTIONS_SOURCE_SITE || 'drakesfood.com',
+  };
+
+  try {
+    await savePendingSubscriber(subscriber);
+  } catch (error) {
+    console.error('Failed to save blog subscriber.', {
+      errorName: error?.name,
+      subscriberId: subscriber.subscriberId,
+    });
+
+    return jsonResponse(500, {
+      success: false,
+      message: 'Blog subscriptions are temporarily unavailable. Please try again later.',
+    });
+  }
+
+  try {
+    await sendConfirmation(subscriber, confirmationToken);
+  } catch (error) {
+    console.error('Failed to send blog subscription confirmation.', {
+      errorName: error?.name,
+      subscriberId: subscriber.subscriberId,
+    });
+  }
+
+  return jsonResponse(200, {
+    success: true,
+    message: SIGNUP_SUCCESS_MESSAGE,
+  });
+};
+
+export const handler = createHandler();
+
+async function confirmSubscription(event, { now, findSubscriberByConfirmationTokenHash, activateSubscriber }) {
+  const token = getQueryStringParameter(event, 'token');
+  const siteUrl = getSiteUrl();
+
+  if (!token) {
+    return redirectResponse(`${siteUrl}${CONFIRMATION_FAILURE_REDIRECT}`);
+  }
+
+  const confirmationTokenHash = hashValue(token);
+  const subscriber = await findSubscriberByConfirmationTokenHash(confirmationTokenHash);
+
+  if (!subscriber || subscriber.status !== 'pending') {
+    return redirectResponse(`${siteUrl}${CONFIRMATION_FAILURE_REDIRECT}`);
+  }
+
+  try {
+    await activateSubscriber(subscriber.subscriberId, now().toISOString());
+  } catch (error) {
+    console.error('Failed to confirm blog subscriber.', {
+      errorName: error?.name,
+      subscriberId: subscriber.subscriberId,
+    });
+
+    return redirectResponse(`${siteUrl}${CONFIRMATION_FAILURE_REDIRECT}`);
+  }
+
+  return redirectResponse(`${siteUrl}${CONFIRMATION_SUCCESS_REDIRECT}`);
+}
+
+async function findExistingSubscriber(emailHash, findSubscriberByEmailHash) {
+  try {
+    return await findSubscriberByEmailHash(emailHash);
+  } catch (error) {
+    console.error('Failed to look up blog subscriber.', {
+      errorName: error?.name,
+    });
+
+    throw error;
+  }
+}
+
+function getMethod(event) {
+  return event.requestContext?.http?.method ?? event.httpMethod ?? '';
+}
+
+function getPath(event) {
+  return event.rawPath ?? event.path ?? '';
+}
+
+function parseBody(event, maxBodyBytes) {
+  const rawBody = event.isBase64Encoded ? Buffer.from(event.body ?? '', 'base64').toString('utf8') : event.body;
+
+  if (!rawBody) {
+    throw new Error('Missing body');
+  }
+
+  if (Buffer.byteLength(rawBody, 'utf8') > maxBodyBytes) {
+    throw new RequestBodyTooLargeError();
+  }
+
+  const parsed = JSON.parse(rawBody);
+
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+    throw new Error('Invalid body');
+  }
+
+  return parsed;
+}
+
+function isAllowedOrigin(event) {
+  const origin = getHeader(event, 'origin');
+
+  if (!origin) {
+    return true;
+  }
+
+  const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return allowedOrigins.length === 0 || allowedOrigins.includes(origin);
+}
+
+function isJsonContentType(event) {
+  const contentType = getHeader(event, 'content-type');
+
+  return !contentType || contentType.toLowerCase().includes('application/json');
+}
+
+function getHeader(event, headerName) {
+  const headers = event.headers || {};
+  const matchingKey = Object.keys(headers).find((key) => key.toLowerCase() === headerName);
+
+  return matchingKey ? headers[matchingKey] : '';
+}
+
+function getQueryStringParameter(event, parameterName) {
+  return event.queryStringParameters?.[parameterName] || '';
+}
+
+function getMaxBodyBytes() {
+  const configuredLimit = Number.parseInt(process.env.BLOG_SUBSCRIPTIONS_MAX_BODY_BYTES || '', 10);
+
+  return Number.isFinite(configuredLimit) && configuredLimit > 0 ? configuredLimit : DEFAULT_MAX_BODY_BYTES;
+}
+
+function normalizeSignupBody(body) {
+  const values = {
+    email: '',
+    website: '',
+  };
+
+  for (const field of ['email', 'website']) {
+    if (body[field] === undefined || body[field] === null) {
+      continue;
+    }
+
+    if (typeof body[field] !== 'string') {
+      return { valid: false, message: 'Please enter a valid email address.', values };
+    }
+
+    values[field] = body[field].trim();
+  }
+
+  values.email = values.email.toLowerCase();
+
+  if (!values.email || values.email.length > EMAIL_LIMIT || !isValidEmail(values.email)) {
+    return { valid: false, message: 'Please enter a valid email address.', values };
+  }
+
+  return { valid: true, message: '', values };
+}
+
+async function findSubscriberByEmailHashInDynamoDb(emailHash) {
+  const tableName = getTableName();
+  const { DynamoDBClient, QueryCommand } = await loadDynamoDbClient();
+  const client = dynamoClient ?? new DynamoDBClient({});
+  dynamoClient = client;
+
+  const response = await client.send(
+    new QueryCommand({
+      TableName: tableName,
+      IndexName: 'emailHash-index',
+      KeyConditionExpression: 'emailHash = :emailHash',
+      ExpressionAttributeValues: {
+        ':emailHash': { S: emailHash },
+      },
+      Limit: 1,
+    }),
+  );
+
+  return response.Items?.[0] ? fromDynamoDbItem(response.Items[0]) : undefined;
+}
+
+async function findSubscriberByConfirmationTokenHashInDynamoDb(confirmationTokenHash) {
+  const tableName = getTableName();
+  const { DynamoDBClient, QueryCommand } = await loadDynamoDbClient();
+  const client = dynamoClient ?? new DynamoDBClient({});
+  dynamoClient = client;
+
+  const response = await client.send(
+    new QueryCommand({
+      TableName: tableName,
+      IndexName: 'confirmationTokenHash-index',
+      KeyConditionExpression: 'confirmationTokenHash = :confirmationTokenHash',
+      ExpressionAttributeValues: {
+        ':confirmationTokenHash': { S: confirmationTokenHash },
+      },
+      Limit: 1,
+    }),
+  );
+
+  return response.Items?.[0] ? fromDynamoDbItem(response.Items[0]) : undefined;
+}
+
+async function savePendingSubscriberToDynamoDb(subscriber) {
+  const tableName = getTableName();
+  const { DynamoDBClient, PutItemCommand } = await loadDynamoDbClient();
+  const client = dynamoClient ?? new DynamoDBClient({});
+  dynamoClient = client;
+
+  await client.send(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: toDynamoDbItem(subscriber),
+    }),
+  );
+}
+
+async function activateSubscriberInDynamoDb(subscriberId, confirmedAt) {
+  const tableName = getTableName();
+  const { DynamoDBClient, UpdateItemCommand } = await loadDynamoDbClient();
+  const client = dynamoClient ?? new DynamoDBClient({});
+  dynamoClient = client;
+
+  await client.send(
+    new UpdateItemCommand({
+      TableName: tableName,
+      Key: {
+        subscriberId: { S: subscriberId },
+      },
+      UpdateExpression: 'SET #status = :active, confirmedAt = :confirmedAt, updatedAt = :confirmedAt REMOVE confirmationTokenHash',
+      ConditionExpression: '#status = :pending',
+      ExpressionAttributeNames: {
+        '#status': 'status',
+      },
+      ExpressionAttributeValues: {
+        ':active': { S: 'active' },
+        ':pending': { S: 'pending' },
+        ':confirmedAt': { S: confirmedAt },
+      },
+    }),
+  );
+}
+
+async function sendConfirmationEmail(subscriber, confirmationToken) {
+  const senderEmail = process.env.SES_SENDER_EMAIL;
+
+  if (!senderEmail) {
+    console.warn('Blog subscription confirmation skipped because SES sender is not configured.', {
+      subscriberId: subscriber.subscriberId,
+    });
+    return;
+  }
+
+  const { SESClient, SendEmailCommand } = await loadSesClient();
+  const client = sesClient ?? new SESClient({});
+  sesClient = client;
+
+  await client.send(
+    new SendEmailCommand({
+      Source: senderEmail,
+      Destination: {
+        ToAddresses: [subscriber.emailNormalized],
+      },
+      Message: {
+        Subject: {
+          Charset: 'UTF-8',
+          Data: "Confirm your Drake's Food emails",
+        },
+        Body: {
+          Text: {
+            Charset: 'UTF-8',
+            Data: formatConfirmationEmail(confirmationToken),
+          },
+        },
+      },
+    }),
+  );
+}
+
+async function loadDynamoDbClient() {
+  if (dynamoModule) {
+    return dynamoModule;
+  }
+
+  dynamoModule = await import('@aws-sdk/client-dynamodb');
+
+  return dynamoModule;
+}
+
+async function loadSesClient() {
+  if (sesModule) {
+    return sesModule;
+  }
+
+  sesModule = await import('@aws-sdk/client-ses');
+
+  return sesModule;
+}
+
+function getTableName() {
+  const tableName = process.env.BLOG_SUBSCRIPTIONS_TABLE_NAME;
+
+  if (!tableName) {
+    throw new Error('Missing BLOG_SUBSCRIPTIONS_TABLE_NAME');
+  }
+
+  return tableName;
+}
+
+function getSiteUrl() {
+  return (process.env.BLOG_SUBSCRIPTIONS_SITE_URL || 'https://drakesfood.com').replace(/\/+$/, '');
+}
+
+function getApiBaseUrl() {
+  return (process.env.BLOG_SUBSCRIPTIONS_API_BASE_URL || '').replace(/\/+$/, '');
+}
+
+function formatConfirmationEmail(confirmationToken) {
+  const confirmationUrl = `${getApiBaseUrl()}/blog-subscriptions/confirm?token=${encodeURIComponent(confirmationToken)}`;
+
+  return [
+    "You're almost subscribed to Drake's Food blog emails.",
+    '',
+    'Confirm your subscription here:',
+    confirmationUrl,
+    '',
+    "If you didn't ask for this, you can ignore this email.",
+  ].join('\n');
+}
+
+function toDynamoDbItem(item) {
+  const dynamoItem = {};
+
+  for (const [key, value] of Object.entries(item)) {
+    if (value !== undefined && value !== '') {
+      dynamoItem[key] = { S: value };
+    }
+  }
+
+  return dynamoItem;
+}
+
+function fromDynamoDbItem(item) {
+  return Object.fromEntries(Object.entries(item).map(([key, value]) => [key, value.S ?? '']));
+}
+
+function hashValue(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function isValidEmail(value) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function jsonResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+function redirectResponse(location) {
+  return {
+    statusCode: 302,
+    headers: {
+      location,
+    },
+    body: '',
+  };
+}
+
+class RequestBodyTooLargeError extends Error {}

--- a/infra/lambda/blog-subscriptions/index.test.mjs
+++ b/infra/lambda/blog-subscriptions/index.test.mjs
@@ -265,22 +265,24 @@ test('duplicate pending signup refreshes confirmation token', async () => {
 
 test('valid confirmation activates a pending subscriber and redirects to success', async () => {
   const activations = [];
+  const emailHash = hash('fan@example.com');
   process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
   const handler = createHandler({
     now: () => fixedDate,
     findSubscriberByConfirmationTokenHash: async (confirmationTokenHash) => ({
       subscriberId: 'subscriber-123',
+      emailHash,
       confirmationTokenHash,
       status: 'pending',
     }),
-    activateSubscriber: async (subscriberId, confirmedAt) => activations.push({ subscriberId, confirmedAt }),
+    activateSubscriber: async (activatedEmailHash, confirmedAt) => activations.push({ emailHash: activatedEmailHash, confirmedAt }),
   });
 
   const response = await handler(createConfirmEvent('confirm-token'));
 
   assert.equal(response.statusCode, 302);
   assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=confirmed');
-  assert.deepEqual(activations, [{ subscriberId: 'subscriber-123', confirmedAt: '2026-05-09T12:00:00.000Z' }]);
+  assert.deepEqual(activations, [{ emailHash, confirmedAt: '2026-05-09T12:00:00.000Z' }]);
   delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
 });
 

--- a/infra/lambda/blog-subscriptions/index.test.mjs
+++ b/infra/lambda/blog-subscriptions/index.test.mjs
@@ -1,0 +1,298 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { createHandler } from './index.mjs';
+
+const fixedDate = new Date('2026-05-09T12:00:00.000Z');
+
+function createPostEvent(body, method = 'POST') {
+  return {
+    requestContext: {
+      http: {
+        method,
+      },
+    },
+    rawPath: '/blog-subscriptions',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+function createConfirmEvent(token) {
+  return {
+    requestContext: {
+      http: {
+        method: 'GET',
+      },
+    },
+    rawPath: '/blog-subscriptions/confirm',
+    queryStringParameters: {
+      token,
+    },
+  };
+}
+
+function parseResponse(response) {
+  return JSON.parse(response.body);
+}
+
+function hash(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+test('stores a pending subscriber and sends a confirmation email', async () => {
+  const savedSubscribers = [];
+  const confirmations = [];
+  const handler = createHandler({
+    now: () => fixedDate,
+    uuid: () => 'subscriber-123',
+    createToken: (() => {
+      const tokens = ['confirm-token', 'unsubscribe-token'];
+
+      return () => tokens.shift();
+    })(),
+    findSubscriberByEmailHash: async () => undefined,
+    savePendingSubscriber: async (subscriber) => savedSubscribers.push(subscriber),
+    sendConfirmation: async (subscriber, token) => confirmations.push({ subscriber, token }),
+  });
+
+  const response = await handler(createPostEvent({ email: '  FAN@Example.com  ', website: '' }));
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(parseResponse(response), {
+    success: true,
+    message: 'If that email can be subscribed, a confirmation link is on the way.',
+  });
+  assert.deepEqual(savedSubscribers, [
+    {
+      subscriberId: 'subscriber-123',
+      emailNormalized: 'fan@example.com',
+      emailHash: hash('fan@example.com'),
+      status: 'pending',
+      createdAt: '2026-05-09T12:00:00.000Z',
+      updatedAt: '2026-05-09T12:00:00.000Z',
+      confirmationTokenHash: hash('confirm-token'),
+      unsubscribeTokenHash: hash('unsubscribe-token'),
+      source: 'drakesfood.com',
+    },
+  ]);
+  assert.equal(confirmations.length, 1);
+  assert.equal(confirmations[0].subscriber, savedSubscribers[0]);
+  assert.equal(confirmations[0].token, 'confirm-token');
+});
+
+test('returns validation error for invalid email', async () => {
+  const savedSubscribers = [];
+  const confirmations = [];
+  const handler = createHandler({
+    findSubscriberByEmailHash: async () => undefined,
+    savePendingSubscriber: async (subscriber) => savedSubscribers.push(subscriber),
+    sendConfirmation: async (subscriber) => confirmations.push(subscriber),
+  });
+
+  const response = await handler(createPostEvent({ email: 'not-an-email' }));
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Please enter a valid email address.',
+  });
+  assert.deepEqual(savedSubscribers, []);
+  assert.deepEqual(confirmations, []);
+});
+
+test('handles populated honeypot as generic success without saving', async () => {
+  const savedSubscribers = [];
+  const confirmations = [];
+  const handler = createHandler({
+    findSubscriberByEmailHash: async () => undefined,
+    savePendingSubscriber: async (subscriber) => savedSubscribers.push(subscriber),
+    sendConfirmation: async (subscriber) => confirmations.push(subscriber),
+  });
+
+  const response = await handler(createPostEvent({ email: 'spam@example.com', website: 'https://bot.example' }));
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(parseResponse(response), {
+    success: true,
+    message: 'If that email can be subscribed, a confirmation link is on the way.',
+  });
+  assert.deepEqual(savedSubscribers, []);
+  assert.deepEqual(confirmations, []);
+});
+
+test('rejects malformed JSON cleanly', async () => {
+  const handler = createHandler();
+
+  const response = await handler({
+    requestContext: { http: { method: 'POST' } },
+    rawPath: '/blog-subscriptions',
+    headers: { 'content-type': 'application/json' },
+    body: '{nope',
+  });
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Please send a valid JSON blog subscription.',
+  });
+});
+
+test('rejects non-POST signup requests cleanly', async () => {
+  const handler = createHandler();
+
+  const response = await handler(createPostEvent({}, 'PUT'));
+
+  assert.equal(response.statusCode, 405);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Blog subscriptions only accept POST requests.',
+  });
+});
+
+test('rejects disallowed browser origins', async () => {
+  process.env.ALLOWED_ORIGINS = 'https://drakesfood.com,http://localhost:4200';
+  const handler = createHandler();
+
+  const response = await handler({
+    ...createPostEvent({ email: 'fan@example.com' }),
+    headers: {
+      'content-type': 'application/json',
+      origin: 'https://spam.example',
+    },
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Blog subscriptions are not available from this origin.',
+  });
+  delete process.env.ALLOWED_ORIGINS;
+});
+
+test('rejects unsupported content types', async () => {
+  const handler = createHandler();
+
+  const response = await handler({
+    ...createPostEvent({ email: 'fan@example.com' }),
+    headers: {
+      'content-type': 'text/plain',
+    },
+  });
+
+  assert.equal(response.statusCode, 415);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Please send blog subscriptions as JSON.',
+  });
+});
+
+test('rejects oversized request bodies before parsing', async () => {
+  process.env.BLOG_SUBSCRIPTIONS_MAX_BODY_BYTES = '24';
+  const handler = createHandler();
+
+  const response = await handler(createPostEvent({ email: 'intentionally-long-address@example.com' }));
+
+  assert.equal(response.statusCode, 413);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Please use a shorter email address and try again.',
+  });
+  delete process.env.BLOG_SUBSCRIPTIONS_MAX_BODY_BYTES;
+});
+
+test('duplicate active signup returns generic success without resending confirmation', async () => {
+  const confirmations = [];
+  const saves = [];
+  const handler = createHandler({
+    findSubscriberByEmailHash: async () => ({
+      subscriberId: 'subscriber-123',
+      emailNormalized: 'fan@example.com',
+      emailHash: hash('fan@example.com'),
+      status: 'active',
+      createdAt: '2026-05-01T12:00:00.000Z',
+      unsubscribeTokenHash: 'existing-unsubscribe-hash',
+    }),
+    savePendingSubscriber: async (subscriber) => saves.push(subscriber),
+    sendConfirmation: async (subscriber) => confirmations.push(subscriber),
+  });
+
+  const response = await handler(createPostEvent({ email: 'fan@example.com' }));
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(parseResponse(response), {
+    success: true,
+    message: 'If that email can be subscribed, a confirmation link is on the way.',
+  });
+  assert.deepEqual(saves, []);
+  assert.deepEqual(confirmations, []);
+});
+
+test('duplicate pending signup refreshes confirmation token', async () => {
+  const savedSubscribers = [];
+  const confirmations = [];
+  const handler = createHandler({
+    now: () => fixedDate,
+    uuid: () => 'new-subscriber-id',
+    createToken: (() => {
+      const tokens = ['new-confirm-token', 'new-unsubscribe-token'];
+
+      return () => tokens.shift();
+    })(),
+    findSubscriberByEmailHash: async () => ({
+      subscriberId: 'subscriber-123',
+      emailNormalized: 'fan@example.com',
+      emailHash: hash('fan@example.com'),
+      status: 'pending',
+      createdAt: '2026-05-01T12:00:00.000Z',
+      unsubscribeTokenHash: 'existing-unsubscribe-hash',
+    }),
+    savePendingSubscriber: async (subscriber) => savedSubscribers.push(subscriber),
+    sendConfirmation: async (subscriber, token) => confirmations.push({ subscriber, token }),
+  });
+
+  const response = await handler(createPostEvent({ email: 'fan@example.com' }));
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(savedSubscribers[0].subscriberId, 'subscriber-123');
+  assert.equal(savedSubscribers[0].createdAt, '2026-05-01T12:00:00.000Z');
+  assert.equal(savedSubscribers[0].confirmationTokenHash, hash('new-confirm-token'));
+  assert.equal(savedSubscribers[0].unsubscribeTokenHash, 'existing-unsubscribe-hash');
+  assert.equal(confirmations[0].token, 'new-confirm-token');
+});
+
+test('valid confirmation activates a pending subscriber and redirects to success', async () => {
+  const activations = [];
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    now: () => fixedDate,
+    findSubscriberByConfirmationTokenHash: async (confirmationTokenHash) => ({
+      subscriberId: 'subscriber-123',
+      confirmationTokenHash,
+      status: 'pending',
+    }),
+    activateSubscriber: async (subscriberId, confirmedAt) => activations.push({ subscriberId, confirmedAt }),
+  });
+
+  const response = await handler(createConfirmEvent('confirm-token'));
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=confirmed');
+  assert.deepEqual(activations, [{ subscriberId: 'subscriber-123', confirmedAt: '2026-05-09T12:00:00.000Z' }]);
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
+test('invalid confirmation token redirects to failure', async () => {
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    findSubscriberByConfirmationTokenHash: async () => undefined,
+  });
+
+  const response = await handler(createConfirmEvent('bad-token'));
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=invalid');
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -32,3 +32,18 @@ output "recipe_submissions_lambda_function_name" {
   description = "Lambda function that handles recipe submissions."
   value       = aws_lambda_function.recipe_submissions.function_name
 }
+
+output "blog_subscriptions_api_endpoint" {
+  description = "Base endpoint URL for the blog subscription HTTP API."
+  value       = aws_apigatewayv2_api.blog_subscriptions.api_endpoint
+}
+
+output "blog_subscriptions_table_name" {
+  description = "DynamoDB table used for blog email subscribers."
+  value       = aws_dynamodb_table.blog_subscribers.name
+}
+
+output "blog_subscriptions_lambda_function_name" {
+  description = "Lambda function that handles blog email subscriptions."
+  value       = aws_lambda_function.blog_subscriptions.function_name
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -103,3 +103,73 @@ variable "recipe_submissions_throttling_rate_limit" {
   type        = number
   default     = 5
 }
+
+variable "blog_subscriptions_api_name" {
+  description = "API Gateway HTTP API name for blog email subscriptions."
+  type        = string
+  default     = "drakesfood-blog-subscriptions"
+}
+
+variable "blog_subscriptions_allowed_origins" {
+  description = "Browser origins allowed to call the blog subscription API."
+  type        = list(string)
+  default = [
+    "https://drakesfood.com",
+    "https://www.drakesfood.com",
+    "http://localhost:4200",
+  ]
+}
+
+variable "blog_subscriptions_lambda_function_name" {
+  description = "Lambda function name for blog email subscriptions."
+  type        = string
+  default     = "drakesfood-blog-subscriptions"
+}
+
+variable "blog_subscriptions_log_retention_days" {
+  description = "CloudWatch log retention in days for blog subscription resources."
+  type        = number
+  default     = 30
+}
+
+variable "blog_subscriptions_max_body_bytes" {
+  description = "Maximum request body size accepted by the blog subscription Lambda."
+  type        = number
+  default     = 8192
+}
+
+variable "blog_subscriptions_ses_identity_arn" {
+  description = "Optional SES identity ARN allowed to send blog subscription emails. Defaults to the domain identity for the active AWS account."
+  type        = string
+  default     = ""
+}
+
+variable "blog_subscriptions_ses_sender_email" {
+  description = "Verified SES sender email address for blog subscription confirmation emails. Set with a tfvars file or CLI variable."
+  type        = string
+  default     = ""
+}
+
+variable "blog_subscriptions_source_site" {
+  description = "Source site value stored with blog subscriber records."
+  type        = string
+  default     = "drakesfood.com"
+}
+
+variable "blog_subscriptions_table_name" {
+  description = "DynamoDB table name for blog email subscribers."
+  type        = string
+  default     = "drakesfood-blog-subscribers"
+}
+
+variable "blog_subscriptions_throttling_burst_limit" {
+  description = "API Gateway burst throttling limit for blog subscriptions."
+  type        = number
+  default     = 10
+}
+
+variable "blog_subscriptions_throttling_rate_limit" {
+  description = "API Gateway steady-state requests per second limit for blog subscriptions."
+  type        = number
+  default     = 5
+}

--- a/public/app-config.json
+++ b/public/app-config.json
@@ -1,3 +1,4 @@
 {
-  "recipeSubmissionsApiBaseUrl": ""
+  "recipeSubmissionsApiBaseUrl": "",
+  "blogSubscriptionsApiBaseUrl": ""
 }

--- a/src/app/components/blog-subscription/blog-subscription.component.css
+++ b/src/app/components/blog-subscription/blog-subscription.component.css
@@ -1,0 +1,104 @@
+.blog-subscription {
+  display: grid;
+  gap: 1.25rem;
+  margin-top: 2rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(61, 45, 33, 0.12);
+  border-radius: 1.5rem;
+  background: linear-gradient(135deg, rgba(255, 250, 245, 0.95), rgba(255, 238, 217, 0.76));
+  box-shadow: var(--shadow-card);
+}
+
+.subscription-copy h3 {
+  margin: 0.35rem 0 0;
+  color: var(--color-text);
+  font-size: clamp(1.75rem, 6vw, 3rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.subscription-copy p:not(.eyebrow),
+.field-help,
+.status-message {
+  color: var(--color-text-muted);
+  line-height: 1.7;
+}
+
+.subscription-copy p:not(.eyebrow) {
+  margin: 0.85rem 0 0;
+}
+
+.subscription-form {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.4rem;
+}
+
+label {
+  color: var(--color-text);
+  font-weight: 800;
+}
+
+input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid rgba(61, 45, 33, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.86);
+  color: var(--color-text);
+  font: inherit;
+  padding: 0.9rem 1rem;
+}
+
+input:focus-visible {
+  outline: 3px solid rgba(132, 84, 52, 0.34);
+  outline-offset: 2px;
+}
+
+.field-help,
+.field-error,
+.status-message {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.field-error,
+.status-error {
+  color: #8f1d14;
+  font-weight: 700;
+}
+
+.status-success {
+  color: #315f2f;
+  font-weight: 800;
+}
+
+.honeypot {
+  position: absolute;
+  left: -10000px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+button {
+  justify-self: start;
+}
+
+@media (max-width: 560px) {
+  button {
+    width: 100%;
+  }
+}
+
+@media (min-width: 760px) {
+  .blog-subscription {
+    grid-template-columns: minmax(0, 0.9fr) minmax(18rem, 1fr);
+    align-items: center;
+    padding: 1.5rem;
+  }
+}

--- a/src/app/components/blog-subscription/blog-subscription.component.html
+++ b/src/app/components/blog-subscription/blog-subscription.component.html
@@ -1,0 +1,51 @@
+<section class="blog-subscription" aria-labelledby="blog-subscription-title">
+  <div class="subscription-copy">
+    <p class="eyebrow">New post emails</p>
+    <h3 id="blog-subscription-title">Get the next kitchen story.</h3>
+    <p>
+      I will email you when a new Drake's Food post goes live. No spam, no accounts, and you can unsubscribe anytime.
+    </p>
+  </div>
+
+  <form class="subscription-form" [formGroup]="subscriptionForm" (ngSubmit)="onSubmit()" novalidate>
+    <div class="field">
+      <label for="blog-subscription-email">Email address <span aria-hidden="true">*</span></label>
+      <input
+        id="blog-subscription-email"
+        type="email"
+        formControlName="email"
+        autocomplete="email"
+        maxlength="254"
+        placeholder="you@example.com"
+        aria-describedby="blog-subscription-help blog-subscription-error"
+      />
+      <p id="blog-subscription-help" class="field-help">Confirm your email before updates start arriving.</p>
+      @if (hasFieldError('email', 'required')) {
+        <p id="blog-subscription-error" class="field-error">Please enter your email address.</p>
+      } @else if (hasFieldError('email', 'email')) {
+        <p id="blog-subscription-error" class="field-error">Enter a valid email address.</p>
+      } @else if (hasFieldError('email', 'maxlength')) {
+        <p id="blog-subscription-error" class="field-error">Keep the email under 254 characters.</p>
+      }
+    </div>
+
+    <div class="honeypot" aria-hidden="true">
+      <label for="blog-subscription-website">Website</label>
+      <input id="blog-subscription-website" type="text" formControlName="website" tabindex="-1" autocomplete="off" />
+    </div>
+
+    <button class="button button-primary" type="submit" [disabled]="isSubmitting()">
+      @if (isSubmitting()) {
+        Sending link...
+      } @else {
+        Subscribe
+      }
+    </button>
+
+    @if (statusMessage()) {
+      <p class="status-message" [class.status-success]="status() === 'success'" [class.status-error]="status() === 'error'" aria-live="polite">
+        {{ statusMessage() }}
+      </p>
+    }
+  </form>
+</section>

--- a/src/app/components/blog-subscription/blog-subscription.component.html
+++ b/src/app/components/blog-subscription/blog-subscription.component.html
@@ -3,7 +3,7 @@
     <p class="eyebrow">New post emails</p>
     <h3 id="blog-subscription-title">Get the next kitchen story.</h3>
     <p>
-      I will email you when a new Drake's Food post goes live. No spam, no accounts, and you can unsubscribe anytime.
+      I will email you when a new Drake's Food post goes live. No spam, no accounts, just a confirmation email before updates start arriving.
     </p>
   </div>
 

--- a/src/app/components/blog-subscription/blog-subscription.component.ts
+++ b/src/app/components/blog-subscription/blog-subscription.component.ts
@@ -1,0 +1,80 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { BlogSubscriptionApiService, type BlogSubscriptionPayload } from '../../services/blog-subscription-api.service';
+
+type SubscriptionStatus = 'idle' | 'submitting' | 'success' | 'error';
+
+@Component({
+  selector: 'app-blog-subscription',
+  standalone: true,
+  imports: [ReactiveFormsModule],
+  templateUrl: './blog-subscription.component.html',
+  styleUrls: ['./blog-subscription.component.css'],
+})
+export class BlogSubscriptionComponent {
+  private readonly formBuilder = inject(NonNullableFormBuilder);
+  private readonly blogSubscriptionApi = inject(BlogSubscriptionApiService);
+
+  readonly status = signal<SubscriptionStatus>('idle');
+  readonly statusMessage = signal('');
+  readonly isSubmitting = computed(() => this.status() === 'submitting');
+
+  readonly subscriptionForm = this.formBuilder.group({
+    email: ['', [Validators.required, Validators.email, Validators.maxLength(254)]],
+    website: [''],
+  });
+
+  async onSubmit(): Promise<void> {
+    const payload = this.buildPayload();
+
+    if (payload.website) {
+      this.status.set('success');
+      this.statusMessage.set('If that email can be subscribed, a confirmation link is on the way.');
+      return;
+    }
+
+    if (this.subscriptionForm.invalid) {
+      this.subscriptionForm.markAllAsTouched();
+      this.status.set('error');
+      this.statusMessage.set('Please enter a valid email address.');
+      return;
+    }
+
+    this.status.set('submitting');
+    this.statusMessage.set('Sending a confirmation link...');
+
+    if (!(await this.blogSubscriptionApi.isConfigured())) {
+      this.status.set('error');
+      this.statusMessage.set('Email updates are ready on the site, but the subscription API is not connected yet.');
+      return;
+    }
+
+    try {
+      const message = await this.blogSubscriptionApi.subscribe(payload);
+      this.subscriptionForm.reset({
+        email: '',
+        website: '',
+      });
+      this.status.set('success');
+      this.statusMessage.set(message);
+    } catch (error) {
+      this.status.set('error');
+      this.statusMessage.set(error instanceof Error ? error.message : 'Blog subscriptions are temporarily unavailable. Please try again later.');
+    }
+  }
+
+  hasFieldError(fieldName: keyof BlogSubscriptionPayload, errorName: string): boolean {
+    const field = this.subscriptionForm.controls[fieldName];
+
+    return field.hasError(errorName) && (field.dirty || field.touched);
+  }
+
+  private buildPayload(): BlogSubscriptionPayload {
+    const rawValue = this.subscriptionForm.getRawValue();
+
+    return {
+      email: rawValue.email.trim(),
+      website: rawValue.website.trim(),
+    };
+  }
+}

--- a/src/app/components/recipe-blog/recipe-blog.component.html
+++ b/src/app/components/recipe-blog/recipe-blog.component.html
@@ -31,6 +31,8 @@
     </div>
   </article>
 
+  <app-blog-subscription></app-blog-subscription>
+
   @if (previousPosts.length > 0) {
     <div class="previous-posts" aria-labelledby="previous-posts-title">
       <h3 id="previous-posts-title">Previous stories</h3>

--- a/src/app/components/recipe-blog/recipe-blog.component.ts
+++ b/src/app/components/recipe-blog/recipe-blog.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { BlogSubscriptionComponent } from '../blog-subscription/blog-subscription.component';
 import { blogPosts, currentBlogPost } from '../../data/blog-posts.data';
 
 @Component({
   selector: 'app-recipe-blog',
   standalone: true,
-  imports: [RouterLink],
+  imports: [RouterLink, BlogSubscriptionComponent],
   templateUrl: './recipe-blog.component.html',
   styleUrls: ['./recipe-blog.component.css'],
 })

--- a/src/app/services/app-config.service.ts
+++ b/src/app/services/app-config.service.ts
@@ -2,10 +2,12 @@ import { Injectable } from '@angular/core';
 
 interface AppConfig {
   recipeSubmissionsApiBaseUrl: string;
+  blogSubscriptionsApiBaseUrl: string;
 }
 
 const defaultConfig: AppConfig = {
   recipeSubmissionsApiBaseUrl: '',
+  blogSubscriptionsApiBaseUrl: '',
 };
 
 @Injectable({ providedIn: 'root' })
@@ -16,6 +18,12 @@ export class AppConfigService {
     const config = await this.loadConfig();
 
     return config.recipeSubmissionsApiBaseUrl;
+  }
+
+  async getBlogSubscriptionsApiBaseUrl(): Promise<string> {
+    const config = await this.loadConfig();
+
+    return config.blogSubscriptionsApiBaseUrl;
   }
 
   private async loadConfig(): Promise<AppConfig> {
@@ -35,9 +43,12 @@ export class AppConfigService {
       const config = (await response.json()) as Partial<AppConfig>;
       const recipeSubmissionsApiBaseUrl =
         typeof config.recipeSubmissionsApiBaseUrl === 'string' ? config.recipeSubmissionsApiBaseUrl.trim().replace(/\/+$/, '') : '';
+      const blogSubscriptionsApiBaseUrl =
+        typeof config.blogSubscriptionsApiBaseUrl === 'string' ? config.blogSubscriptionsApiBaseUrl.trim().replace(/\/+$/, '') : '';
 
       return {
         recipeSubmissionsApiBaseUrl,
+        blogSubscriptionsApiBaseUrl,
       };
     } catch {
       return defaultConfig;

--- a/src/app/services/blog-subscription-api.service.ts
+++ b/src/app/services/blog-subscription-api.service.ts
@@ -1,0 +1,67 @@
+import { inject, Injectable } from '@angular/core';
+import { AppConfigService } from './app-config.service';
+
+export interface BlogSubscriptionPayload {
+  email: string;
+  website: string;
+}
+
+interface BlogSubscriptionApiResponse {
+  success: boolean;
+  message: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class BlogSubscriptionApiService {
+  private readonly appConfig = inject(AppConfigService);
+
+  async isConfigured(): Promise<boolean> {
+    return Boolean(await this.appConfig.getBlogSubscriptionsApiBaseUrl());
+  }
+
+  async subscribe(payload: BlogSubscriptionPayload): Promise<string> {
+    const apiBaseUrl = await this.appConfig.getBlogSubscriptionsApiBaseUrl();
+
+    if (!apiBaseUrl) {
+      throw new Error('Blog subscription API is not configured.');
+    }
+
+    let response: Response;
+
+    try {
+      response = await fetch(`${apiBaseUrl}/blog-subscriptions`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+    } catch {
+      throw new Error('Blog subscriptions are temporarily unavailable. Please try again later.');
+    }
+
+    const body = await this.parseResponse(response);
+
+    if (!response.ok || !body.success) {
+      throw new Error(body.message || 'Blog subscriptions are temporarily unavailable. Please try again later.');
+    }
+
+    return body.message;
+  }
+
+  private async parseResponse(response: Response): Promise<BlogSubscriptionApiResponse> {
+    try {
+      const body = (await response.json()) as Partial<BlogSubscriptionApiResponse>;
+
+      return {
+        success: body.success === true,
+        message: typeof body.message === 'string' ? body.message : '',
+      };
+    } catch {
+      return {
+        success: false,
+        message: 'Blog subscriptions are temporarily unavailable. Please try again later.',
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a confirmed opt-in blog email signup form to the blog section.
- Adds AWS/OpenTofu resources for blog subscription API Gateway routes, Lambda, DynamoDB storage, SES confirmation emails, and outputs.
- Documents setup, runtime config, privacy notes, and follow-up work for unsubscribe and post notifications.

Closes #82
Refs #83
Refs #84
Refs #85

## Validation
- `node --test infra/lambda/blog-subscriptions/index.test.mjs`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `tofu validate`
- `git diff --check`

## Visual Review
- Not completed in browser during this pass. The signup component was built with responsive CSS and included in the existing blog section, but local viewport review should be done before merge.

## Deployment Notes
- No AWS resources were applied by this PR.
- SES sender/domain verification is required before confirmation emails can send in production.
- After OpenTofu apply, set the GitHub repository variable `BLOG_SUBSCRIPTIONS_API_BASE_URL` to the `blog_subscriptions_api_endpoint` output.
- If the API base URL is blank, the public form remains visible but shows a not-connected-yet fallback.

## Follow-Up
- #83 adds unsubscribe support.
- #84 adds new-post notification sending.