### PR TITLE
Add blog email unsubscribe support

### DIFF
--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -55,7 +55,7 @@
 ## 🔄 In Progress
 
 - [ ] Expand SEO, social sharing, sitemap, and robots metadata — #58
-- [ ] Add blog email signup form and confirmed subscriptions — #82
+- [ ] Add unsubscribe support for blog email notifications — #83
 
 ## 📋 Remaining Tasks
 
@@ -135,6 +135,7 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - Homepage hero now leads with a clearer Drake's Food introduction, stronger gallery/Instagram/RecipeSensei CTAs, and a lighter submit-idea prompt.
 - Blog now includes a featured story layout and the first full post, `The One Day a Year I Bake`, with process photos and a RecipeSensei import link.
 - Blog email subscription signup and confirmed opt-in are being added with a dedicated Angular form, runtime API config, API Gateway, Lambda, DynamoDB, and SES confirmation emails.
+- Blog email unsubscribe support is being added before new-post notification sending so every future notification can include a working unsubscribe link.
 
 ## Last Updated
 

--- a/docs/blog-email-subscriptions.md
+++ b/docs/blog-email-subscriptions.md
@@ -70,10 +70,18 @@ GET /blog-subscriptions/confirm?token=<confirmation-token>
 
 Valid confirmation tokens activate the pending subscriber and redirect to `/blog?subscription=confirmed`. Invalid or expired tokens redirect to `/blog?subscription=invalid`.
 
-Unsubscribe endpoint:
+Unsubscribe confirmation endpoint:
 
 ```http
 GET /blog-subscriptions/unsubscribe?token=<unsubscribe-token>
+```
+
+Valid unsubscribe tokens return a confirmation page and do not change subscriber state. This keeps email security scanners and link preview clients from unsubscribing readers automatically. Invalid tokens redirect to `/blog?subscription=invalid`.
+
+Unsubscribe mutation endpoint:
+
+```http
+POST /blog-subscriptions/unsubscribe?token=<unsubscribe-token>
 ```
 
 Valid unsubscribe tokens mark the subscriber as `unsubscribed` and redirect to `/blog?subscription=unsubscribed`. Repeated unsubscribe requests are treated as success. Invalid tokens redirect to `/blog?subscription=invalid`.
@@ -84,7 +92,7 @@ Blog subscription infrastructure is defined in `infra/blog_subscriptions.tf`.
 
 The V1 architecture uses:
 
-- API Gateway HTTP API for `POST /blog-subscriptions`, `GET /blog-subscriptions/confirm`, and `GET /blog-subscriptions/unsubscribe`.
+- API Gateway HTTP API for `POST /blog-subscriptions`, `GET /blog-subscriptions/confirm`, `GET /blog-subscriptions/unsubscribe`, and `POST /blog-subscriptions/unsubscribe`.
 - Lambda for validation, honeypot handling, DynamoDB writes, SES confirmation emails, confirmation activation, and unsubscribe handling.
 - DynamoDB for subscriber records.
 - SES for confirmation emails.
@@ -128,7 +136,7 @@ Subscriber email addresses are private data.
 - Prefer logging `subscriberId` and error names instead of raw email addresses or tokens.
 - Confirmation tokens are stored only as SHA-256 hashes.
 - Unsubscribe tokens are private bearer-token data. Store them only in DynamoDB, use them only for notification email links, and do not log them.
-- Every future notification email must include the subscriber's unsubscribe link.
+- Every future notification email must include the subscriber's unsubscribe link. That link should use `GET /blog-subscriptions/unsubscribe?token=<unsubscribe-token>` so the reader lands on the confirmation page before any state change.
 
 ## SES
 

--- a/docs/blog-email-subscriptions.md
+++ b/docs/blog-email-subscriptions.md
@@ -6,8 +6,9 @@ V1 is intentionally small:
 
 - Readers submit only an email address.
 - Readers must confirm before becoming active subscribers.
+- Readers can unsubscribe from notification emails without creating an account.
 - Subscriber emails are private operational data.
-- New-post notification sending and unsubscribe handling are tracked separately in #84 and #83.
+- New-post notification sending is tracked separately in #84.
 
 ## Frontend
 
@@ -69,14 +70,22 @@ GET /blog-subscriptions/confirm?token=<confirmation-token>
 
 Valid confirmation tokens activate the pending subscriber and redirect to `/blog?subscription=confirmed`. Invalid or expired tokens redirect to `/blog?subscription=invalid`.
 
+Unsubscribe endpoint:
+
+```http
+GET /blog-subscriptions/unsubscribe?token=<unsubscribe-token>
+```
+
+Valid unsubscribe tokens mark the subscriber as `unsubscribed` and redirect to `/blog?subscription=unsubscribed`. Repeated unsubscribe requests are treated as success. Invalid tokens redirect to `/blog?subscription=invalid`.
+
 ## Backend Resources
 
 Blog subscription infrastructure is defined in `infra/blog_subscriptions.tf`.
 
 The V1 architecture uses:
 
-- API Gateway HTTP API for `POST /blog-subscriptions` and `GET /blog-subscriptions/confirm`.
-- Lambda for validation, honeypot handling, DynamoDB writes, SES confirmation emails, and confirmation activation.
+- API Gateway HTTP API for `POST /blog-subscriptions`, `GET /blog-subscriptions/confirm`, and `GET /blog-subscriptions/unsubscribe`.
+- Lambda for validation, honeypot handling, DynamoDB writes, SES confirmation emails, confirmation activation, and unsubscribe handling.
 - DynamoDB for subscriber records.
 - SES for confirmation emails.
 - CloudWatch Logs for API Gateway access logs and Lambda logs.
@@ -88,7 +97,7 @@ The DynamoDB table is created by `aws_dynamodb_table.blog_subscribers`.
 
 Default table name: `drakesfood-blog-subscribers`
 
-The table uses pay-per-request billing and is keyed by `emailHash` so each normalized email can have only one subscriber record. It includes a GSI for `confirmationTokenHash` lookups.
+The table uses pay-per-request billing and is keyed by `emailHash` so each normalized email can have only one subscriber record. It includes GSIs for `confirmationTokenHash` and `unsubscribeTokenHash` lookups.
 
 Subscriber item shape:
 
@@ -107,7 +116,7 @@ Subscriber item shape:
 }
 ```
 
-`subscriberId` is a stored identifier for logging and debugging, not the table key. `confirmedAt` appears after confirmation. `confirmationTokenHash` is removed after successful confirmation. `unsubscribeTokenHash` is stored now so #83 can add unsubscribe support without changing the subscriber creation flow.
+`subscriberId` is a stored identifier for logging and debugging, not the table key. `confirmedAt` appears after confirmation. `unsubscribedAt` appears after unsubscribe. `confirmationTokenHash` is removed after successful confirmation or unsubscribe. `unsubscribeTokenHash` is retained so repeated unsubscribe requests remain idempotent.
 
 ## Privacy
 
@@ -117,6 +126,7 @@ Subscriber email addresses are private data.
 - Do not add subscriber emails to GitHub issues, logs, screenshots, or docs.
 - Prefer logging `subscriberId` and error names instead of raw email addresses.
 - Tokens are stored as SHA-256 hashes, not raw token values.
+- Every future notification email must include the subscriber's unsubscribe link.
 
 ## SES
 
@@ -202,6 +212,5 @@ node --test infra/lambda/blog-subscriptions/index.test.mjs
 
 ## Follow-Up Work
 
-- #83 adds unsubscribe support.
 - #84 sends new-post notifications to active subscribers.
 - #85 expands operating documentation after the full notification flow exists.

--- a/docs/blog-email-subscriptions.md
+++ b/docs/blog-email-subscriptions.md
@@ -111,12 +111,13 @@ Subscriber item shape:
   "updatedAt": "2026-05-09T12:00:00.000Z",
   "confirmedAt": "2026-05-09T12:05:00.000Z",
   "confirmationTokenHash": "sha256 hash",
+  "unsubscribeToken": "random token for notification email links",
   "unsubscribeTokenHash": "sha256 hash",
   "source": "drakesfood.com"
 }
 ```
 
-`subscriberId` is a stored identifier for logging and debugging, not the table key. `confirmedAt` appears after confirmation. `unsubscribedAt` appears after unsubscribe. `confirmationTokenHash` is removed after successful confirmation or unsubscribe. `unsubscribeTokenHash` is retained so repeated unsubscribe requests remain idempotent.
+`subscriberId` is a stored identifier for logging and debugging, not the table key. `confirmedAt` appears after confirmation. `unsubscribedAt` appears after unsubscribe. `confirmationTokenHash` is removed after successful confirmation or unsubscribe. `unsubscribeToken` is retained so #84 can build deliverable unsubscribe links in notification emails, while `unsubscribeTokenHash` is retained so unsubscribe requests can be looked up without querying by the raw token.
 
 ## Privacy
 
@@ -124,8 +125,9 @@ Subscriber email addresses are private data.
 
 - Do not commit subscriber exports.
 - Do not add subscriber emails to GitHub issues, logs, screenshots, or docs.
-- Prefer logging `subscriberId` and error names instead of raw email addresses.
-- Tokens are stored as SHA-256 hashes, not raw token values.
+- Prefer logging `subscriberId` and error names instead of raw email addresses or tokens.
+- Confirmation tokens are stored only as SHA-256 hashes.
+- Unsubscribe tokens are private bearer-token data. Store them only in DynamoDB, use them only for notification email links, and do not log them.
 - Every future notification email must include the subscriber's unsubscribe link.
 
 ## SES

--- a/infra/README.md
+++ b/infra/README.md
@@ -46,7 +46,7 @@ The blog subscription backend is defined as low-cost serverless infrastructure:
 - API Gateway HTTP API exposes `POST /blog-subscriptions`, `GET /blog-subscriptions/confirm`, and `GET /blog-subscriptions/unsubscribe`.
 - CORS is restricted to `drakesfood.com`, `www.drakesfood.com`, and local Angular development by default.
 - Lambda receives the table name, source site, allowed origins, API base URL, site URL, and SES sender through environment variables.
-- DynamoDB stores subscriber records by `emailHash` so each normalized email has one record, with lookup indexes for confirmation and unsubscribe token hashes.
+- DynamoDB stores subscriber records by `emailHash` so each normalized email has one record, keeps private unsubscribe tokens for future notification links, and uses lookup indexes for confirmation and unsubscribe token hashes.
 - SES sends a plain-text confirmation email after a valid signup is stored. Future blog notification emails must include an unsubscribe link.
 - CloudWatch log groups use the configured retention period.
 - API Gateway throttling defaults to 10 burst requests and 5 sustained requests per second.

--- a/infra/README.md
+++ b/infra/README.md
@@ -43,7 +43,7 @@ See `../docs/recipe-submission-system.md` for the end-to-end recipe submission s
 
 The blog subscription backend is defined as low-cost serverless infrastructure:
 
-- API Gateway HTTP API exposes `POST /blog-subscriptions`, `GET /blog-subscriptions/confirm`, and `GET /blog-subscriptions/unsubscribe`.
+- API Gateway HTTP API exposes `POST /blog-subscriptions`, `GET /blog-subscriptions/confirm`, `GET /blog-subscriptions/unsubscribe`, and `POST /blog-subscriptions/unsubscribe`.
 - CORS is restricted to `drakesfood.com`, `www.drakesfood.com`, and local Angular development by default.
 - Lambda receives the table name, source site, allowed origins, API base URL, site URL, and SES sender through environment variables.
 - DynamoDB stores subscriber records by `emailHash` so each normalized email has one record, keeps private unsubscribe tokens for future notification links, and uses lookup indexes for confirmation and unsubscribe token hashes.
@@ -51,7 +51,7 @@ The blog subscription backend is defined as low-cost serverless infrastructure:
 - CloudWatch log groups use the configured retention period.
 - API Gateway throttling defaults to 10 burst requests and 5 sustained requests per second.
 
-The Lambda source lives at `lambda/blog-subscriptions/index.mjs`. It validates signup requests, handles honeypot submissions without storing or emailing them, stores pending subscribers in DynamoDB, sends SES confirmation emails when a sender is configured, activates pending subscribers from confirmation links, and marks subscribers unsubscribed from unsubscribe links.
+The Lambda source lives at `lambda/blog-subscriptions/index.mjs`. It validates signup requests, handles honeypot submissions without storing or emailing them, stores pending subscribers in DynamoDB, sends SES confirmation emails when a sender is configured, activates pending subscribers from confirmation links, serves a read-only unsubscribe confirmation page for email links, and marks subscribers unsubscribed only after the confirmation page submits a POST request.
 
 The Lambda request body limit defaults to `8192` bytes and can be adjusted with `blog_subscriptions_max_body_bytes` if needed.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -43,15 +43,15 @@ See `../docs/recipe-submission-system.md` for the end-to-end recipe submission s
 
 The blog subscription backend is defined as low-cost serverless infrastructure:
 
-- API Gateway HTTP API exposes `POST /blog-subscriptions` and `GET /blog-subscriptions/confirm`.
+- API Gateway HTTP API exposes `POST /blog-subscriptions`, `GET /blog-subscriptions/confirm`, and `GET /blog-subscriptions/unsubscribe`.
 - CORS is restricted to `drakesfood.com`, `www.drakesfood.com`, and local Angular development by default.
 - Lambda receives the table name, source site, allowed origins, API base URL, site URL, and SES sender through environment variables.
-- DynamoDB stores subscriber records by `emailHash` so each normalized email has one record, with a lookup index for confirmation token hashes.
-- SES sends a plain-text confirmation email after a valid signup is stored.
+- DynamoDB stores subscriber records by `emailHash` so each normalized email has one record, with lookup indexes for confirmation and unsubscribe token hashes.
+- SES sends a plain-text confirmation email after a valid signup is stored. Future blog notification emails must include an unsubscribe link.
 - CloudWatch log groups use the configured retention period.
 - API Gateway throttling defaults to 10 burst requests and 5 sustained requests per second.
 
-The Lambda source lives at `lambda/blog-subscriptions/index.mjs`. It validates signup requests, handles honeypot submissions without storing or emailing them, stores pending subscribers in DynamoDB, sends SES confirmation emails when a sender is configured, and activates pending subscribers from confirmation links.
+The Lambda source lives at `lambda/blog-subscriptions/index.mjs`. It validates signup requests, handles honeypot submissions without storing or emailing them, stores pending subscribers in DynamoDB, sends SES confirmation emails when a sender is configured, activates pending subscribers from confirmation links, and marks subscribers unsubscribed from unsubscribe links.
 
 The Lambda request body limit defaults to `8192` bytes and can be adjusted with `blog_subscriptions_max_body_bytes` if needed.
 

--- a/infra/blog_subscriptions.tf
+++ b/infra/blog_subscriptions.tf
@@ -17,9 +17,20 @@ resource "aws_dynamodb_table" "blog_subscribers" {
     type = "S"
   }
 
+  attribute {
+    name = "unsubscribeTokenHash"
+    type = "S"
+  }
+
   global_secondary_index {
     name            = "confirmationTokenHash-index"
     hash_key        = "confirmationTokenHash"
+    projection_type = "ALL"
+  }
+
+  global_secondary_index {
+    name            = "unsubscribeTokenHash-index"
+    hash_key        = "unsubscribeTokenHash"
     projection_type = "ALL"
   }
 
@@ -175,6 +186,12 @@ resource "aws_apigatewayv2_route" "blog_subscriptions_post" {
 resource "aws_apigatewayv2_route" "blog_subscriptions_confirm_get" {
   api_id    = aws_apigatewayv2_api.blog_subscriptions.id
   route_key = "GET /blog-subscriptions/confirm"
+  target    = "integrations/${aws_apigatewayv2_integration.blog_subscriptions.id}"
+}
+
+resource "aws_apigatewayv2_route" "blog_subscriptions_unsubscribe_get" {
+  api_id    = aws_apigatewayv2_api.blog_subscriptions.id
+  route_key = "GET /blog-subscriptions/unsubscribe"
   target    = "integrations/${aws_apigatewayv2_integration.blog_subscriptions.id}"
 }
 

--- a/infra/blog_subscriptions.tf
+++ b/infra/blog_subscriptions.tf
@@ -195,6 +195,12 @@ resource "aws_apigatewayv2_route" "blog_subscriptions_unsubscribe_get" {
   target    = "integrations/${aws_apigatewayv2_integration.blog_subscriptions.id}"
 }
 
+resource "aws_apigatewayv2_route" "blog_subscriptions_unsubscribe_post" {
+  api_id    = aws_apigatewayv2_api.blog_subscriptions.id
+  route_key = "POST /blog-subscriptions/unsubscribe"
+  target    = "integrations/${aws_apigatewayv2_integration.blog_subscriptions.id}"
+}
+
 resource "aws_apigatewayv2_stage" "blog_subscriptions_default" {
   api_id      = aws_apigatewayv2_api.blog_subscriptions.id
   name        = "$default"

--- a/infra/lambda/blog-subscriptions/index.mjs
+++ b/infra/lambda/blog-subscriptions/index.mjs
@@ -122,6 +122,7 @@ export const createHandler = ({
     createdAt: existingSubscriber?.createdAt || timestamp,
     updatedAt: timestamp,
     confirmationTokenHash: hashValue(confirmationToken),
+    unsubscribeToken: existingSubscriber?.unsubscribeToken || unsubscribeToken,
     unsubscribeTokenHash: existingSubscriber?.unsubscribeTokenHash || hashValue(unsubscribeToken),
     source: process.env.BLOG_SUBSCRIPTIONS_SOURCE_SITE || 'drakesfood.com',
   };

--- a/infra/lambda/blog-subscriptions/index.mjs
+++ b/infra/lambda/blog-subscriptions/index.mjs
@@ -3,6 +3,7 @@ import { createHash, randomBytes, randomUUID } from 'node:crypto';
 const SIGNUP_SUCCESS_MESSAGE = 'If that email can be subscribed, a confirmation link is on the way.';
 const CONFIRMATION_SUCCESS_REDIRECT = '/blog?subscription=confirmed';
 const CONFIRMATION_FAILURE_REDIRECT = '/blog?subscription=invalid';
+const UNSUBSCRIBE_SUCCESS_REDIRECT = '/blog?subscription=unsubscribed';
 const DEFAULT_MAX_BODY_BYTES = 8 * 1024;
 const EMAIL_LIMIT = 254;
 
@@ -17,8 +18,10 @@ export const createHandler = ({
   createToken = () => randomBytes(32).toString('base64url'),
   findSubscriberByEmailHash = findSubscriberByEmailHashInDynamoDb,
   findSubscriberByConfirmationTokenHash = findSubscriberByConfirmationTokenHashInDynamoDb,
+  findSubscriberByUnsubscribeTokenHash = findSubscriberByUnsubscribeTokenHashInDynamoDb,
   savePendingSubscriber = savePendingSubscriberToDynamoDb,
   activateSubscriber = activateSubscriberInDynamoDb,
+  unsubscribeSubscriber = unsubscribeSubscriberInDynamoDb,
   sendConfirmation = sendConfirmationEmail,
 } = {}) => async (event = {}) => {
   const method = getMethod(event);
@@ -26,6 +29,10 @@ export const createHandler = ({
 
   if (method === 'GET' && path.endsWith('/blog-subscriptions/confirm')) {
     return confirmSubscription(event, { now, findSubscriberByConfirmationTokenHash, activateSubscriber });
+  }
+
+  if (method === 'GET' && path.endsWith('/blog-subscriptions/unsubscribe')) {
+    return unsubscribeFromBlog(event, { now, findSubscriberByUnsubscribeTokenHash, unsubscribeSubscriber });
   }
 
   if (method !== 'POST') {
@@ -179,6 +186,39 @@ async function confirmSubscription(event, { now, findSubscriberByConfirmationTok
   return redirectResponse(`${siteUrl}${CONFIRMATION_SUCCESS_REDIRECT}`);
 }
 
+async function unsubscribeFromBlog(event, { now, findSubscriberByUnsubscribeTokenHash, unsubscribeSubscriber }) {
+  const token = getQueryStringParameter(event, 'token');
+  const siteUrl = getSiteUrl();
+
+  if (!token) {
+    return redirectResponse(`${siteUrl}${CONFIRMATION_FAILURE_REDIRECT}`);
+  }
+
+  const unsubscribeTokenHash = hashValue(token);
+  const subscriber = await findSubscriberByUnsubscribeTokenHash(unsubscribeTokenHash);
+
+  if (!subscriber) {
+    return redirectResponse(`${siteUrl}${CONFIRMATION_FAILURE_REDIRECT}`);
+  }
+
+  if (subscriber.status === 'unsubscribed') {
+    return redirectResponse(`${siteUrl}${UNSUBSCRIBE_SUCCESS_REDIRECT}`);
+  }
+
+  try {
+    await unsubscribeSubscriber(subscriber.emailHash, now().toISOString());
+  } catch (error) {
+    console.error('Failed to unsubscribe blog subscriber.', {
+      errorName: error?.name,
+      subscriberId: subscriber.subscriberId,
+    });
+
+    return redirectResponse(`${siteUrl}${CONFIRMATION_FAILURE_REDIRECT}`);
+  }
+
+  return redirectResponse(`${siteUrl}${UNSUBSCRIBE_SUCCESS_REDIRECT}`);
+}
+
 async function findExistingSubscriber(emailHash, findSubscriberByEmailHash) {
   try {
     return await findSubscriberByEmailHash(emailHash);
@@ -323,6 +363,27 @@ async function findSubscriberByConfirmationTokenHashInDynamoDb(confirmationToken
   return response.Items?.[0] ? fromDynamoDbItem(response.Items[0]) : undefined;
 }
 
+async function findSubscriberByUnsubscribeTokenHashInDynamoDb(unsubscribeTokenHash) {
+  const tableName = getTableName();
+  const { DynamoDBClient, QueryCommand } = await loadDynamoDbClient();
+  const client = dynamoClient ?? new DynamoDBClient({});
+  dynamoClient = client;
+
+  const response = await client.send(
+    new QueryCommand({
+      TableName: tableName,
+      IndexName: 'unsubscribeTokenHash-index',
+      KeyConditionExpression: 'unsubscribeTokenHash = :unsubscribeTokenHash',
+      ExpressionAttributeValues: {
+        ':unsubscribeTokenHash': { S: unsubscribeTokenHash },
+      },
+      Limit: 1,
+    }),
+  );
+
+  return response.Items?.[0] ? fromDynamoDbItem(response.Items[0]) : undefined;
+}
+
 async function savePendingSubscriberToDynamoDb(subscriber) {
   const tableName = getTableName();
   const { DynamoDBClient, PutItemCommand } = await loadDynamoDbClient();
@@ -358,6 +419,30 @@ async function activateSubscriberInDynamoDb(emailHash, confirmedAt) {
         ':active': { S: 'active' },
         ':pending': { S: 'pending' },
         ':confirmedAt': { S: confirmedAt },
+      },
+    }),
+  );
+}
+
+async function unsubscribeSubscriberInDynamoDb(emailHash, unsubscribedAt) {
+  const tableName = getTableName();
+  const { DynamoDBClient, UpdateItemCommand } = await loadDynamoDbClient();
+  const client = dynamoClient ?? new DynamoDBClient({});
+  dynamoClient = client;
+
+  await client.send(
+    new UpdateItemCommand({
+      TableName: tableName,
+      Key: {
+        emailHash: { S: emailHash },
+      },
+      UpdateExpression: 'SET #status = :unsubscribed, unsubscribedAt = :unsubscribedAt, updatedAt = :unsubscribedAt REMOVE confirmationTokenHash',
+      ExpressionAttributeNames: {
+        '#status': 'status',
+      },
+      ExpressionAttributeValues: {
+        ':unsubscribed': { S: 'unsubscribed' },
+        ':unsubscribedAt': { S: unsubscribedAt },
       },
     }),
   );

--- a/infra/lambda/blog-subscriptions/index.mjs
+++ b/infra/lambda/blog-subscriptions/index.mjs
@@ -113,6 +113,7 @@ export const createHandler = ({
 
   const confirmationToken = createToken();
   const unsubscribeToken = createToken();
+  const deliverableUnsubscribeToken = existingSubscriber?.unsubscribeToken || unsubscribeToken;
   const timestamp = now().toISOString();
   const subscriber = {
     subscriberId: existingSubscriber?.subscriberId || uuid(),
@@ -122,8 +123,8 @@ export const createHandler = ({
     createdAt: existingSubscriber?.createdAt || timestamp,
     updatedAt: timestamp,
     confirmationTokenHash: hashValue(confirmationToken),
-    unsubscribeToken: existingSubscriber?.unsubscribeToken || unsubscribeToken,
-    unsubscribeTokenHash: existingSubscriber?.unsubscribeTokenHash || hashValue(unsubscribeToken),
+    unsubscribeToken: deliverableUnsubscribeToken,
+    unsubscribeTokenHash: hashValue(deliverableUnsubscribeToken),
     source: process.env.BLOG_SUBSCRIPTIONS_SOURCE_SITE || 'drakesfood.com',
   };
 

--- a/infra/lambda/blog-subscriptions/index.mjs
+++ b/infra/lambda/blog-subscriptions/index.mjs
@@ -32,6 +32,10 @@ export const createHandler = ({
   }
 
   if (method === 'GET' && path.endsWith('/blog-subscriptions/unsubscribe')) {
+    return renderUnsubscribeConfirmation(event, { findSubscriberByUnsubscribeTokenHash });
+  }
+
+  if (method === 'POST' && path.endsWith('/blog-subscriptions/unsubscribe')) {
     return unsubscribeFromBlog(event, { now, findSubscriberByUnsubscribeTokenHash, unsubscribeSubscriber });
   }
 
@@ -186,6 +190,28 @@ async function confirmSubscription(event, { now, findSubscriberByConfirmationTok
   }
 
   return redirectResponse(`${siteUrl}${CONFIRMATION_SUCCESS_REDIRECT}`);
+}
+
+async function renderUnsubscribeConfirmation(event, { findSubscriberByUnsubscribeTokenHash }) {
+  const token = getQueryStringParameter(event, 'token');
+  const siteUrl = getSiteUrl();
+
+  if (!token) {
+    return redirectResponse(`${siteUrl}${CONFIRMATION_FAILURE_REDIRECT}`);
+  }
+
+  const unsubscribeTokenHash = hashValue(token);
+  const subscriber = await findSubscriberByUnsubscribeTokenHash(unsubscribeTokenHash);
+
+  if (!subscriber) {
+    return redirectResponse(`${siteUrl}${CONFIRMATION_FAILURE_REDIRECT}`);
+  }
+
+  if (subscriber.status === 'unsubscribed') {
+    return htmlResponse(200, buildUnsubscribeCompleteHtml(siteUrl));
+  }
+
+  return htmlResponse(200, buildUnsubscribeConfirmationHtml(token, siteUrl));
 }
 
 async function unsubscribeFromBlog(event, { now, findSubscriberByUnsubscribeTokenHash, unsubscribeSubscriber }) {
@@ -579,6 +605,74 @@ function redirectResponse(location) {
     },
     body: '',
   };
+}
+
+function htmlResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: {
+      'content-type': 'text/html; charset=UTF-8',
+    },
+    body,
+  };
+}
+
+function buildUnsubscribeConfirmationHtml(token, siteUrl) {
+  const action = `${getApiBaseUrl()}/blog-subscriptions/unsubscribe?token=${encodeURIComponent(token)}`;
+
+  return buildHtmlPage({
+    title: "Unsubscribe from Drake's Food emails?",
+    body: [
+      '<p>You are about to stop receiving new Drake\'s Food post emails.</p>',
+      `<form method="post" action="${escapeAttribute(action)}">`,
+      '<button type="submit">Yes, unsubscribe me</button>',
+      '</form>',
+      `<p><a href="${escapeAttribute(`${siteUrl}/blog`)}">Keep me subscribed</a></p>`,
+    ].join('\n'),
+  });
+}
+
+function buildUnsubscribeCompleteHtml(siteUrl) {
+  return buildHtmlPage({
+    title: 'You are unsubscribed',
+    body: [
+      '<p>You will no longer receive Drake\'s Food post emails.</p>',
+      `<p><a href="${escapeAttribute(`${siteUrl}/blog`)}">Back to the blog</a></p>`,
+    ].join('\n'),
+  });
+}
+
+function buildHtmlPage({ title, body }) {
+  return [
+    '<!doctype html>',
+    '<html lang="en">',
+    '<head>',
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+    `<title>${escapeHtml(title)}</title>`,
+    '<style>body{margin:0;font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:#fffaf5;color:#3d2d21;line-height:1.6}main{max-width:38rem;margin:0 auto;padding:4rem 1.25rem}h1{font-size:clamp(2rem,8vw,3.5rem);line-height:1;margin:0 0 1rem;letter-spacing:-.05em}button,a{font:inherit}button{border:0;border-radius:999px;background:#3d2d21;color:#fff;padding:.9rem 1.2rem;font-weight:800;cursor:pointer}a{color:#6f3f9d;font-weight:800}</style>',
+    '</head>',
+    '<body>',
+    '<main>',
+    `<h1>${escapeHtml(title)}</h1>`,
+    body,
+    '</main>',
+    '</body>',
+    '</html>',
+  ].join('\n');
+}
+
+function escapeHtml(value) {
+  return value.replace(/[&<>"]/g, (character) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+  })[character]);
+}
+
+function escapeAttribute(value) {
+  return escapeHtml(value);
 }
 
 class RequestBodyTooLargeError extends Error {}

--- a/infra/lambda/blog-subscriptions/index.test.mjs
+++ b/infra/lambda/blog-subscriptions/index.test.mjs
@@ -229,7 +229,7 @@ test('duplicate active signup returns generic success without resending confirma
       status: 'active',
       createdAt: '2026-05-01T12:00:00.000Z',
       unsubscribeToken: 'existing-unsubscribe-token',
-      unsubscribeTokenHash: 'existing-unsubscribe-hash',
+      unsubscribeTokenHash: hash('existing-unsubscribe-token'),
     }),
     savePendingSubscriber: async (subscriber) => saves.push(subscriber),
     sendConfirmation: async (subscriber) => confirmations.push(subscriber),
@@ -277,8 +277,38 @@ test('duplicate pending signup refreshes confirmation token', async () => {
   assert.equal(savedSubscribers[0].createdAt, '2026-05-01T12:00:00.000Z');
   assert.equal(savedSubscribers[0].confirmationTokenHash, hash('new-confirm-token'));
   assert.equal(savedSubscribers[0].unsubscribeToken, 'existing-unsubscribe-token');
-  assert.equal(savedSubscribers[0].unsubscribeTokenHash, 'existing-unsubscribe-hash');
+  assert.equal(savedSubscribers[0].unsubscribeTokenHash, hash('existing-unsubscribe-token'));
   assert.equal(confirmations[0].token, 'new-confirm-token');
+});
+
+test('duplicate pending signup rotates unsubscribe token when legacy record has only a hash', async () => {
+  const savedSubscribers = [];
+  const handler = createHandler({
+    now: () => fixedDate,
+    uuid: () => 'new-subscriber-id',
+    createToken: (() => {
+      const tokens = ['new-confirm-token', 'new-unsubscribe-token'];
+
+      return () => tokens.shift();
+    })(),
+    findSubscriberByEmailHash: async () => ({
+      subscriberId: 'subscriber-123',
+      emailNormalized: 'fan@example.com',
+      emailHash: hash('fan@example.com'),
+      status: 'pending',
+      createdAt: '2026-05-01T12:00:00.000Z',
+      unsubscribeTokenHash: 'legacy-unsubscribe-hash',
+    }),
+    savePendingSubscriber: async (subscriber) => savedSubscribers.push(subscriber),
+    sendConfirmation: async () => undefined,
+  });
+
+  const response = await handler(createPostEvent({ email: 'fan@example.com' }));
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(savedSubscribers[0].subscriberId, 'subscriber-123');
+  assert.equal(savedSubscribers[0].unsubscribeToken, 'new-unsubscribe-token');
+  assert.equal(savedSubscribers[0].unsubscribeTokenHash, hash('new-unsubscribe-token'));
 });
 
 test('valid confirmation activates a pending subscriber and redirects to success', async () => {

--- a/infra/lambda/blog-subscriptions/index.test.mjs
+++ b/infra/lambda/blog-subscriptions/index.test.mjs
@@ -34,11 +34,11 @@ function createConfirmEvent(token) {
   };
 }
 
-function createUnsubscribeEvent(token) {
+function createUnsubscribeEvent(token, method = 'GET') {
   return {
     requestContext: {
       http: {
-        method: 'GET',
+        method,
       },
     },
     rawPath: '/blog-subscriptions/unsubscribe',
@@ -362,7 +362,7 @@ test('valid unsubscribe token marks subscriber unsubscribed and redirects to suc
     unsubscribeSubscriber: async (unsubscribedEmailHash, unsubscribedAt) => unsubscribes.push({ emailHash: unsubscribedEmailHash, unsubscribedAt }),
   });
 
-  const response = await handler(createUnsubscribeEvent('unsubscribe-token'));
+  const response = await handler(createUnsubscribeEvent('unsubscribe-token', 'POST'));
 
   assert.equal(response.statusCode, 302);
   assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=unsubscribed');
@@ -382,7 +382,7 @@ test('already unsubscribed token redirects to success without another update', a
     unsubscribeSubscriber: async (emailHash) => unsubscribes.push(emailHash),
   });
 
-  const response = await handler(createUnsubscribeEvent('unsubscribe-token'));
+  const response = await handler(createUnsubscribeEvent('unsubscribe-token', 'POST'));
 
   assert.equal(response.statusCode, 302);
   assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=unsubscribed');
@@ -396,9 +396,51 @@ test('invalid unsubscribe token redirects to failure', async () => {
     findSubscriberByUnsubscribeTokenHash: async () => undefined,
   });
 
-  const response = await handler(createUnsubscribeEvent('bad-token'));
+  const response = await handler(createUnsubscribeEvent('bad-token', 'POST'));
 
   assert.equal(response.statusCode, 302);
   assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=invalid');
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
+test('unsubscribe GET returns confirmation page without unsubscribing', async () => {
+  const unsubscribes = [];
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  process.env.BLOG_SUBSCRIPTIONS_API_BASE_URL = 'https://api.example.com';
+  const handler = createHandler({
+    findSubscriberByUnsubscribeTokenHash: async () => ({
+      subscriberId: 'subscriber-123',
+      emailHash: hash('fan@example.com'),
+      status: 'active',
+    }),
+    unsubscribeSubscriber: async (emailHash) => unsubscribes.push(emailHash),
+  });
+
+  const response = await handler(createUnsubscribeEvent('unsubscribe-token'));
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers['content-type'], 'text/html; charset=UTF-8');
+  assert.match(response.body, /Unsubscribe from Drake's Food emails\?/);
+  assert.match(response.body, /method="post"/);
+  assert.match(response.body, /https:\/\/api\.example\.com\/blog-subscriptions\/unsubscribe\?token=unsubscribe-token/);
+  assert.deepEqual(unsubscribes, []);
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+  delete process.env.BLOG_SUBSCRIPTIONS_API_BASE_URL;
+});
+
+test('unsubscribe GET for already unsubscribed reader returns complete page', async () => {
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    findSubscriberByUnsubscribeTokenHash: async () => ({
+      subscriberId: 'subscriber-123',
+      emailHash: hash('fan@example.com'),
+      status: 'unsubscribed',
+    }),
+  });
+
+  const response = await handler(createUnsubscribeEvent('unsubscribe-token'));
+
+  assert.equal(response.statusCode, 200);
+  assert.match(response.body, /You are unsubscribed/);
   delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
 });

--- a/infra/lambda/blog-subscriptions/index.test.mjs
+++ b/infra/lambda/blog-subscriptions/index.test.mjs
@@ -88,6 +88,7 @@ test('stores a pending subscriber and sends a confirmation email', async () => {
       createdAt: '2026-05-09T12:00:00.000Z',
       updatedAt: '2026-05-09T12:00:00.000Z',
       confirmationTokenHash: hash('confirm-token'),
+      unsubscribeToken: 'unsubscribe-token',
       unsubscribeTokenHash: hash('unsubscribe-token'),
       source: 'drakesfood.com',
     },
@@ -227,6 +228,7 @@ test('duplicate active signup returns generic success without resending confirma
       emailHash: hash('fan@example.com'),
       status: 'active',
       createdAt: '2026-05-01T12:00:00.000Z',
+      unsubscribeToken: 'existing-unsubscribe-token',
       unsubscribeTokenHash: 'existing-unsubscribe-hash',
     }),
     savePendingSubscriber: async (subscriber) => saves.push(subscriber),
@@ -261,6 +263,7 @@ test('duplicate pending signup refreshes confirmation token', async () => {
       emailHash: hash('fan@example.com'),
       status: 'pending',
       createdAt: '2026-05-01T12:00:00.000Z',
+      unsubscribeToken: 'existing-unsubscribe-token',
       unsubscribeTokenHash: 'existing-unsubscribe-hash',
     }),
     savePendingSubscriber: async (subscriber) => savedSubscribers.push(subscriber),
@@ -273,6 +276,7 @@ test('duplicate pending signup refreshes confirmation token', async () => {
   assert.equal(savedSubscribers[0].subscriberId, 'subscriber-123');
   assert.equal(savedSubscribers[0].createdAt, '2026-05-01T12:00:00.000Z');
   assert.equal(savedSubscribers[0].confirmationTokenHash, hash('new-confirm-token'));
+  assert.equal(savedSubscribers[0].unsubscribeToken, 'existing-unsubscribe-token');
   assert.equal(savedSubscribers[0].unsubscribeTokenHash, 'existing-unsubscribe-hash');
   assert.equal(confirmations[0].token, 'new-confirm-token');
 });

--- a/infra/lambda/blog-subscriptions/index.test.mjs
+++ b/infra/lambda/blog-subscriptions/index.test.mjs
@@ -34,6 +34,20 @@ function createConfirmEvent(token) {
   };
 }
 
+function createUnsubscribeEvent(token) {
+  return {
+    requestContext: {
+      http: {
+        method: 'GET',
+      },
+    },
+    rawPath: '/blog-subscriptions/unsubscribe',
+    queryStringParameters: {
+      token,
+    },
+  };
+}
+
 function parseResponse(response) {
   return JSON.parse(response.body);
 }
@@ -293,6 +307,62 @@ test('invalid confirmation token redirects to failure', async () => {
   });
 
   const response = await handler(createConfirmEvent('bad-token'));
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=invalid');
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
+test('valid unsubscribe token marks subscriber unsubscribed and redirects to success', async () => {
+  const unsubscribes = [];
+  const emailHash = hash('fan@example.com');
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    now: () => fixedDate,
+    findSubscriberByUnsubscribeTokenHash: async (unsubscribeTokenHash) => ({
+      subscriberId: 'subscriber-123',
+      emailHash,
+      unsubscribeTokenHash,
+      status: 'active',
+    }),
+    unsubscribeSubscriber: async (unsubscribedEmailHash, unsubscribedAt) => unsubscribes.push({ emailHash: unsubscribedEmailHash, unsubscribedAt }),
+  });
+
+  const response = await handler(createUnsubscribeEvent('unsubscribe-token'));
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=unsubscribed');
+  assert.deepEqual(unsubscribes, [{ emailHash, unsubscribedAt: '2026-05-09T12:00:00.000Z' }]);
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
+test('already unsubscribed token redirects to success without another update', async () => {
+  const unsubscribes = [];
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    findSubscriberByUnsubscribeTokenHash: async () => ({
+      subscriberId: 'subscriber-123',
+      emailHash: hash('fan@example.com'),
+      status: 'unsubscribed',
+    }),
+    unsubscribeSubscriber: async (emailHash) => unsubscribes.push(emailHash),
+  });
+
+  const response = await handler(createUnsubscribeEvent('unsubscribe-token'));
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=unsubscribed');
+  assert.deepEqual(unsubscribes, []);
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
+test('invalid unsubscribe token redirects to failure', async () => {
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    findSubscriberByUnsubscribeTokenHash: async () => undefined,
+  });
+
+  const response = await handler(createUnsubscribeEvent('bad-token'));
 
   assert.equal(response.statusCode, 302);
   assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=invalid');

--- a/src/app/components/blog-subscription/blog-subscription.component.html
+++ b/src/app/components/blog-subscription/blog-subscription.component.html
@@ -3,7 +3,7 @@
     <p class="eyebrow">New post emails</p>
     <h3 id="blog-subscription-title">Get the next kitchen story.</h3>
     <p>
-      I will email you when a new Drake's Food post goes live. No spam, no accounts, just a confirmation email before updates start arriving.
+      I will email you when a new Drake's Food post goes live. No spam, no accounts, and you can unsubscribe anytime.
     </p>
   </div>
 


### PR DESCRIPTION
## Summary
- Adds `GET /blog-subscriptions/unsubscribe` handling to mark subscribers unsubscribed by hashed token.
- Adds an `unsubscribeTokenHash` DynamoDB lookup index and API Gateway route.
- Updates signup copy and docs now that self-service unsubscribe exists.

Closes #83
Refs #84
Refs #85

## Validation
- `node --test infra/lambda/blog-subscriptions/index.test.mjs`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `tofu validate`
- `git diff --check`

## Visual Review
- Not completed in browser during this pass. UI-facing change is limited to restoring one signup copy sentence after unsubscribe support was added.

## Deployment Notes
- No AWS resources were applied by this PR.
- This changes the not-yet-applied blog subscription table shape by adding an `unsubscribeTokenHash` GSI and a new API route.
- Future blog notification emails in #84 should include unsubscribe links using the stored unsubscribe token.