### PR TITLE
Add controlled blog notification sending

### DIFF
--- a/.github/workflows/send-blog-notification.yml
+++ b/.github/workflows/send-blog-notification.yml
@@ -1,0 +1,53 @@
+name: Send Blog Notification
+
+on:
+  workflow_dispatch:
+    inputs:
+      post_slug:
+        description: Blog post slug to notify subscribers about
+        required: true
+        type: string
+      dry_run:
+        description: Preview recipient count without sending emails
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: send-blog-notification-${{ inputs.post_slug }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-east-2
+  BLOG_SUBSCRIPTIONS_LAMBDA_FUNCTION_NAME: ${{ vars.BLOG_SUBSCRIPTIONS_LAMBDA_FUNCTION_NAME }}
+
+jobs:
+  send:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Send notification
+        env:
+          POST_SLUG: ${{ inputs.post_slug }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          FUNCTION_NAME="${BLOG_SUBSCRIPTIONS_LAMBDA_FUNCTION_NAME:-drakesfood-blog-subscriptions}"
+          node -e 'const fs = require("node:fs"); fs.writeFileSync("payload.json", JSON.stringify({ action: "sendBlogPostNotification", postSlug: process.env.POST_SLUG, dryRun: process.env.DRY_RUN === "true" }));'
+          aws lambda invoke \
+            --function-name "$FUNCTION_NAME" \
+            --cli-binary-format raw-in-base64-out \
+            --payload file://payload.json \
+            response.json
+          node -e 'const fs = require("node:fs"); const response = JSON.parse(fs.readFileSync("response.json", "utf8")); console.log(JSON.stringify(response, null, 2)); if (response.success !== true) process.exit(1);'

--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -55,7 +55,7 @@
 ## 🔄 In Progress
 
 - [ ] Expand SEO, social sharing, sitemap, and robots metadata — #58
-- [ ] Add unsubscribe support for blog email notifications — #83
+- [ ] Send email notification when a new blog post is published — #84
 
 ## 📋 Remaining Tasks
 
@@ -136,6 +136,7 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - Blog now includes a featured story layout and the first full post, `The One Day a Year I Bake`, with process photos and a RecipeSensei import link.
 - Blog email subscription signup and confirmed opt-in are being added with a dedicated Angular form, runtime API config, API Gateway, Lambda, DynamoDB, and SES confirmation emails.
 - Blog email unsubscribe support is being added before new-post notification sending so every future notification can include a working unsubscribe link.
+- Blog post notification sending is being added as a manual GitHub Actions workflow with dry-run support, duplicate-send tracking, and unsubscribe links in every email.
 
 ## Last Updated
 

--- a/docs/blog-email-subscriptions.md
+++ b/docs/blog-email-subscriptions.md
@@ -133,6 +133,8 @@ Default table name: `drakesfood-blog-notification-sends`
 
 It is keyed by `postSlug` so each post can be sent once. Dry runs do not write to this table. Real sends first reserve the slug with `status: sending`; repeated real sends for the same slug are rejected to prevent duplicate emails.
 
+The V1 notification sender is intentionally bounded. The Lambda timeout is 60 seconds, sends run in small concurrent batches, and real sends are blocked when the active subscriber count exceeds `blog_notification_max_recipients` (default `50`). Dry runs still report the full count so Drake can see when the list is too large for the V1 synchronous sender.
+
 Send tracking item shape:
 
 ```json
@@ -210,6 +212,7 @@ Useful variables for this feature are defined in `infra/variables.tf`:
 - `blog_subscriptions_source_site`
 - `blog_subscriptions_table_name`
 - `blog_notification_sends_table_name`
+- `blog_notification_max_recipients`
 - `blog_subscriptions_throttling_burst_limit`
 - `blog_subscriptions_throttling_rate_limit`
 

--- a/docs/blog-email-subscriptions.md
+++ b/docs/blog-email-subscriptions.md
@@ -7,8 +7,8 @@ V1 is intentionally small:
 - Readers submit only an email address.
 - Readers must confirm before becoming active subscribers.
 - Readers can unsubscribe from notification emails without creating an account.
+- New-post notifications are sent by a manual GitHub Actions workflow with a dry-run mode.
 - Subscriber emails are private operational data.
-- New-post notification sending is tracked separately in #84.
 
 ## Frontend
 
@@ -93,9 +93,9 @@ Blog subscription infrastructure is defined in `infra/blog_subscriptions.tf`.
 The V1 architecture uses:
 
 - API Gateway HTTP API for `POST /blog-subscriptions`, `GET /blog-subscriptions/confirm`, `GET /blog-subscriptions/unsubscribe`, and `POST /blog-subscriptions/unsubscribe`.
-- Lambda for validation, honeypot handling, DynamoDB writes, SES confirmation emails, confirmation activation, and unsubscribe handling.
-- DynamoDB for subscriber records.
-- SES for confirmation emails.
+- Lambda for validation, honeypot handling, DynamoDB writes, SES confirmation emails, confirmation activation, unsubscribe handling, and controlled blog post notification sending.
+- DynamoDB for subscriber records and notification send tracking.
+- SES for confirmation emails and blog post notification emails.
 - CloudWatch Logs for API Gateway access logs and Lambda logs.
 - OpenTofu for resource management.
 
@@ -126,6 +126,45 @@ Subscriber item shape:
 ```
 
 `subscriberId` is a stored identifier for logging and debugging, not the table key. `confirmedAt` appears after confirmation. `unsubscribedAt` appears after unsubscribe. `confirmationTokenHash` is removed after successful confirmation or unsubscribe. `unsubscribeToken` is retained so #84 can build deliverable unsubscribe links in notification emails, while `unsubscribeTokenHash` is retained so unsubscribe requests can be looked up without querying by the raw token.
+
+The notification send tracking table is created by `aws_dynamodb_table.blog_notification_sends`.
+
+Default table name: `drakesfood-blog-notification-sends`
+
+It is keyed by `postSlug` so each post can be sent once. Dry runs do not write to this table. Real sends first reserve the slug with `status: sending`; repeated real sends for the same slug are rejected to prevent duplicate emails.
+
+Send tracking item shape:
+
+```json
+{
+  "postSlug": "mothers-day-baking",
+  "status": "sent",
+  "dryRun": "false",
+  "startedAt": "2026-05-09T12:00:00.000Z",
+  "completedAt": "2026-05-09T12:00:12.000Z",
+  "recipientCount": "25",
+  "sentCount": "25",
+  "failedCount": "0"
+}
+```
+
+## Blog Notification Sending
+
+Blog post notification metadata lives in `infra/lambda/blog-subscriptions/blog-notification-posts.mjs`. Add new posts there before sending notifications for them.
+
+The manual workflow `.github/workflows/send-blog-notification.yml` invokes the blog subscriptions Lambda with an internal event:
+
+```json
+{
+  "action": "sendBlogPostNotification",
+  "postSlug": "mothers-day-baking",
+  "dryRun": true
+}
+```
+
+Run with `dry_run: true` first. Dry runs count active subscribers and do not send email or mark the post as sent. Run with `dry_run: false` only after reviewing the dry-run output.
+
+Notification emails are sent only to subscribers with `status: active` and an `unsubscribeToken`. Pending and unsubscribed readers are excluded. Each email includes a post link and an unsubscribe link that lands on the unsubscribe confirmation page.
 
 ## Privacy
 
@@ -170,6 +209,7 @@ Useful variables for this feature are defined in `infra/variables.tf`:
 - `blog_subscriptions_ses_sender_email`
 - `blog_subscriptions_source_site`
 - `blog_subscriptions_table_name`
+- `blog_notification_sends_table_name`
 - `blog_subscriptions_throttling_burst_limit`
 - `blog_subscriptions_throttling_rate_limit`
 
@@ -186,6 +226,7 @@ After apply, get the values needed for frontend configuration and operational ch
 AWS_PROFILE=drakesfood tofu output -raw blog_subscriptions_api_endpoint
 AWS_PROFILE=drakesfood tofu output -raw blog_subscriptions_table_name
 AWS_PROFILE=drakesfood tofu output -raw blog_subscriptions_lambda_function_name
+AWS_PROFILE=drakesfood tofu output -raw blog_notification_sends_table_name
 ```
 
 ## GitHub Actions Deployment
@@ -195,6 +236,7 @@ The static site deploy workflow is `.github/workflows/deploy.yml`. It runs on pu
 Required GitHub repository variable:
 
 - `BLOG_SUBSCRIPTIONS_API_BASE_URL`: set to the OpenTofu output `blog_subscriptions_api_endpoint`.
+- `BLOG_SUBSCRIPTIONS_LAMBDA_FUNCTION_NAME`: optional for the manual notification workflow; defaults to `drakesfood-blog-subscriptions` when blank.
 
 Related deployment requirements:
 
@@ -203,6 +245,17 @@ Related deployment requirements:
 - `CLOUDFRONT_DISTRIBUTION_ID` repository variable for cache invalidation
 
 If `BLOG_SUBSCRIPTIONS_API_BASE_URL` is missing or blank, production will deploy successfully but the public signup form will use its not-connected-yet fallback.
+
+## Manual Notification Workflow
+
+Use the `Send Blog Notification` GitHub Actions workflow to notify subscribers about a post.
+
+Inputs:
+
+- `post_slug`: blog post slug from `blog-notification-posts.mjs`.
+- `dry_run`: use `true` first, then `false` for the real send.
+
+The workflow uses the repository AWS credentials and invokes the blog subscription Lambda directly. The GitHub Actions IAM user needs `lambda:InvokeFunction` permission for that Lambda, which OpenTofu grants.
 
 ## Local Testing
 
@@ -222,5 +275,4 @@ node --test infra/lambda/blog-subscriptions/index.test.mjs
 
 ## Follow-Up Work
 
-- #84 sends new-post notifications to active subscribers.
 - #85 expands operating documentation after the full notification flow exists.

--- a/infra/README.md
+++ b/infra/README.md
@@ -48,6 +48,7 @@ The blog subscription backend is defined as low-cost serverless infrastructure:
 - Lambda receives the subscriber table name, notification send table name, source site, allowed origins, API base URL, site URL, and SES sender through environment variables.
 - DynamoDB stores subscriber records by `emailHash` so each normalized email has one record, keeps private unsubscribe tokens for notification links, uses lookup indexes for confirmation and unsubscribe token hashes, and tracks notification sends by `postSlug`.
 - SES sends plain-text confirmation emails and controlled blog post notification emails. Notification emails include an unsubscribe link.
+- Blog notification sending is capped by `blog_notification_max_recipients` for the V1 synchronous sender and runs in small batches to reduce timeout risk.
 - CloudWatch log groups use the configured retention period.
 - API Gateway throttling defaults to 10 burst requests and 5 sustained requests per second.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -45,13 +45,13 @@ The blog subscription backend is defined as low-cost serverless infrastructure:
 
 - API Gateway HTTP API exposes `POST /blog-subscriptions`, `GET /blog-subscriptions/confirm`, `GET /blog-subscriptions/unsubscribe`, and `POST /blog-subscriptions/unsubscribe`.
 - CORS is restricted to `drakesfood.com`, `www.drakesfood.com`, and local Angular development by default.
-- Lambda receives the table name, source site, allowed origins, API base URL, site URL, and SES sender through environment variables.
-- DynamoDB stores subscriber records by `emailHash` so each normalized email has one record, keeps private unsubscribe tokens for future notification links, and uses lookup indexes for confirmation and unsubscribe token hashes.
-- SES sends a plain-text confirmation email after a valid signup is stored. Future blog notification emails must include an unsubscribe link.
+- Lambda receives the subscriber table name, notification send table name, source site, allowed origins, API base URL, site URL, and SES sender through environment variables.
+- DynamoDB stores subscriber records by `emailHash` so each normalized email has one record, keeps private unsubscribe tokens for notification links, uses lookup indexes for confirmation and unsubscribe token hashes, and tracks notification sends by `postSlug`.
+- SES sends plain-text confirmation emails and controlled blog post notification emails. Notification emails include an unsubscribe link.
 - CloudWatch log groups use the configured retention period.
 - API Gateway throttling defaults to 10 burst requests and 5 sustained requests per second.
 
-The Lambda source lives at `lambda/blog-subscriptions/index.mjs`. It validates signup requests, handles honeypot submissions without storing or emailing them, stores pending subscribers in DynamoDB, sends SES confirmation emails when a sender is configured, activates pending subscribers from confirmation links, serves a read-only unsubscribe confirmation page for email links, and marks subscribers unsubscribed only after the confirmation page submits a POST request.
+The Lambda source lives at `lambda/blog-subscriptions/index.mjs`. It validates signup requests, handles honeypot submissions without storing or emailing them, stores pending subscribers in DynamoDB, sends SES confirmation emails when a sender is configured, activates pending subscribers from confirmation links, serves a read-only unsubscribe confirmation page for email links, marks subscribers unsubscribed only after the confirmation page submits a POST request, and sends blog post notifications from an internal GitHub Actions-triggered event.
 
 The Lambda request body limit defaults to `8192` bytes and can be adjusted with `blog_subscriptions_max_body_bytes` if needed.
 
@@ -145,6 +145,7 @@ After apply finishes, get the CloudFront distribution ID and recipe submission A
 AWS_PROFILE=drakesfood tofu output -raw cloudfront_distribution_id
 AWS_PROFILE=drakesfood tofu output -raw recipe_submissions_api_endpoint
 AWS_PROFILE=drakesfood tofu output -raw blog_subscriptions_api_endpoint
+AWS_PROFILE=drakesfood tofu output -raw blog_subscriptions_lambda_function_name
 ```
 
 Add that value as a GitHub repository variable named `CLOUDFRONT_DISTRIBUTION_ID`.
@@ -161,6 +162,7 @@ It also needs these GitHub repository variables:
 - `CLOUDFRONT_DISTRIBUTION_ID`
 - `RECIPE_SUBMISSIONS_API_BASE_URL`
 - `BLOG_SUBSCRIPTIONS_API_BASE_URL`
+- `BLOG_SUBSCRIPTIONS_LAMBDA_FUNCTION_NAME` optional, defaults to `drakesfood-blog-subscriptions` for the manual notification workflow
 
 Set `RECIPE_SUBMISSIONS_API_BASE_URL` to the `recipe_submissions_api_endpoint` OpenTofu output after the recipe submission infrastructure is applied. The deploy workflow writes this value into `app-config.json` at deploy time. Until it is configured, the public form keeps its not-connected-yet fallback.
 
@@ -173,6 +175,7 @@ The OpenTofu-managed deploy policy grants the GitHub Actions IAM user these perm
 - `s3:ListBucket` on the site bucket
 - `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` on site bucket objects
 - `cloudfront:CreateInvalidation` on the site CloudFront distribution
+- `lambda:InvokeFunction` on the blog subscription Lambda for the manual blog notification workflow
 
 If older manually attached deploy policies exist on the IAM user, review and remove them after `tofu apply` confirms the OpenTofu-managed policy is active.
 

--- a/infra/blog_subscriptions.tf
+++ b/infra/blog_subscriptions.tf
@@ -167,11 +167,12 @@ resource "aws_lambda_function" "blog_subscriptions" {
   handler          = "index.handler"
   runtime          = "nodejs22.x"
   role             = aws_iam_role.blog_subscriptions_lambda.arn
-  timeout          = 10
+  timeout          = 60
   memory_size      = 128
 
   environment {
     variables = {
+      BLOG_NOTIFICATION_MAX_RECIPIENTS   = tostring(var.blog_notification_max_recipients)
       ALLOWED_ORIGINS                    = join(",", var.blog_subscriptions_allowed_origins)
       BLOG_NOTIFICATION_SENDS_TABLE_NAME = aws_dynamodb_table.blog_notification_sends.name
       BLOG_SUBSCRIPTIONS_API_BASE_URL    = aws_apigatewayv2_api.blog_subscriptions.api_endpoint

--- a/infra/blog_subscriptions.tf
+++ b/infra/blog_subscriptions.tf
@@ -39,6 +39,21 @@ resource "aws_dynamodb_table" "blog_subscribers" {
   }
 }
 
+resource "aws_dynamodb_table" "blog_notification_sends" {
+  name         = var.blog_notification_sends_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "postSlug"
+
+  attribute {
+    name = "postSlug"
+    type = "S"
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+}
+
 resource "aws_cloudwatch_log_group" "blog_subscriptions_lambda" {
   name              = "/aws/lambda/${var.blog_subscriptions_lambda_function_name}"
   retention_in_days = var.blog_subscriptions_log_retention_days
@@ -72,11 +87,26 @@ data "aws_iam_policy_document" "blog_subscriptions_lambda" {
     actions = [
       "dynamodb:GetItem",
       "dynamodb:PutItem",
+      "dynamodb:Scan",
       "dynamodb:UpdateItem",
     ]
 
     resources = [
       aws_dynamodb_table.blog_subscribers.arn,
+    ]
+  }
+
+  statement {
+    sid = "TrackBlogNotificationSends"
+
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+    ]
+
+    resources = [
+      aws_dynamodb_table.blog_notification_sends.arn,
     ]
   }
 
@@ -125,7 +155,7 @@ resource "aws_iam_role_policy" "blog_subscriptions_lambda" {
 
 data "archive_file" "blog_subscriptions_lambda" {
   type        = "zip"
-  source_file = "${path.module}/lambda/blog-subscriptions/index.mjs"
+  source_dir  = "${path.module}/lambda/blog-subscriptions"
   output_path = "${path.module}/.terraform/blog-subscriptions-lambda.zip"
 }
 
@@ -142,13 +172,14 @@ resource "aws_lambda_function" "blog_subscriptions" {
 
   environment {
     variables = {
-      ALLOWED_ORIGINS                   = join(",", var.blog_subscriptions_allowed_origins)
-      BLOG_SUBSCRIPTIONS_API_BASE_URL   = aws_apigatewayv2_api.blog_subscriptions.api_endpoint
-      BLOG_SUBSCRIPTIONS_MAX_BODY_BYTES = tostring(var.blog_subscriptions_max_body_bytes)
-      BLOG_SUBSCRIPTIONS_SITE_URL       = "https://${var.domain_name}"
-      BLOG_SUBSCRIPTIONS_SOURCE_SITE    = var.blog_subscriptions_source_site
-      BLOG_SUBSCRIPTIONS_TABLE_NAME     = aws_dynamodb_table.blog_subscribers.name
-      SES_SENDER_EMAIL                  = var.blog_subscriptions_ses_sender_email
+      ALLOWED_ORIGINS                    = join(",", var.blog_subscriptions_allowed_origins)
+      BLOG_NOTIFICATION_SENDS_TABLE_NAME = aws_dynamodb_table.blog_notification_sends.name
+      BLOG_SUBSCRIPTIONS_API_BASE_URL    = aws_apigatewayv2_api.blog_subscriptions.api_endpoint
+      BLOG_SUBSCRIPTIONS_MAX_BODY_BYTES  = tostring(var.blog_subscriptions_max_body_bytes)
+      BLOG_SUBSCRIPTIONS_SITE_URL        = "https://${var.domain_name}"
+      BLOG_SUBSCRIPTIONS_SOURCE_SITE     = var.blog_subscriptions_source_site
+      BLOG_SUBSCRIPTIONS_TABLE_NAME      = aws_dynamodb_table.blog_subscribers.name
+      SES_SENDER_EMAIL                   = var.blog_subscriptions_ses_sender_email
     }
   }
 

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -44,6 +44,18 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       aws_cloudfront_distribution.site.arn,
     ]
   }
+
+  statement {
+    sid = "InvokeBlogNotificationSender"
+
+    actions = [
+      "lambda:InvokeFunction",
+    ]
+
+    resources = [
+      aws_lambda_function.blog_subscriptions.arn,
+    ]
+  }
 }
 
 resource "aws_iam_user_policy" "github_actions_deploy" {

--- a/infra/lambda/blog-subscriptions/blog-notification-posts.mjs
+++ b/infra/lambda/blog-subscriptions/blog-notification-posts.mjs
@@ -1,0 +1,12 @@
+export const blogNotificationPosts = [
+  {
+    slug: 'mothers-day-baking',
+    title: 'The One Day a Year I Bake',
+    summary: 'A family tradition that continues to challenge me year after year.',
+    path: '/blog/mothers-day-baking',
+  },
+];
+
+export function getBlogNotificationPost(slug) {
+  return blogNotificationPosts.find((post) => post.slug === slug);
+}

--- a/infra/lambda/blog-subscriptions/index.mjs
+++ b/infra/lambda/blog-subscriptions/index.mjs
@@ -1,4 +1,5 @@
 import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import { getBlogNotificationPost } from './blog-notification-posts.mjs';
 
 const SIGNUP_SUCCESS_MESSAGE = 'If that email can be subscribed, a confirmation link is on the way.';
 const CONFIRMATION_SUCCESS_REDIRECT = '/blog?subscription=confirmed';
@@ -23,7 +24,23 @@ export const createHandler = ({
   activateSubscriber = activateSubscriberInDynamoDb,
   unsubscribeSubscriber = unsubscribeSubscriberInDynamoDb,
   sendConfirmation = sendConfirmationEmail,
+  getBlogPost = getBlogNotificationPost,
+  listActiveSubscribers = listActiveSubscribersFromDynamoDb,
+  reserveNotificationSend = reserveNotificationSendInDynamoDb,
+  completeNotificationSend = completeNotificationSendInDynamoDb,
+  sendBlogNotification = sendBlogNotificationEmail,
 } = {}) => async (event = {}) => {
+  if (event.action === 'sendBlogPostNotification') {
+    return sendBlogPostNotification(event, {
+      now,
+      getBlogPost,
+      listActiveSubscribers,
+      reserveNotificationSend,
+      completeNotificationSend,
+      sendBlogNotification,
+    });
+  }
+
   const method = getMethod(event);
   const path = getPath(event);
 
@@ -245,6 +262,121 @@ async function unsubscribeFromBlog(event, { now, findSubscriberByUnsubscribeToke
   }
 
   return redirectResponse(`${siteUrl}${UNSUBSCRIBE_SUCCESS_REDIRECT}`);
+}
+
+async function sendBlogPostNotification(event, { now, getBlogPost, listActiveSubscribers, reserveNotificationSend, completeNotificationSend, sendBlogNotification }) {
+  const postSlug = typeof event.postSlug === 'string' ? event.postSlug.trim() : '';
+  const dryRun = event.dryRun === true || event.dryRun === 'true';
+
+  if (!postSlug) {
+    return internalResponse(400, {
+      success: false,
+      message: 'Please provide a blog post slug.',
+    });
+  }
+
+  const post = getBlogPost(postSlug);
+
+  if (!post) {
+    return internalResponse(404, {
+      success: false,
+      message: `No blog notification metadata found for "${postSlug}".`,
+    });
+  }
+
+  const subscribers = await listActiveSubscribers();
+  const sendStartedAt = now().toISOString();
+
+  if (dryRun) {
+    return internalResponse(200, {
+      success: true,
+      dryRun,
+      postSlug,
+      recipientCount: subscribers.length,
+      sentCount: 0,
+      failedCount: 0,
+      message: `Dry run found ${subscribers.length} active subscriber(s) for ${post.title}.`,
+    });
+  }
+
+  if (sendBlogNotification === sendBlogNotificationEmail && !process.env.SES_SENDER_EMAIL) {
+    return internalResponse(500, {
+      success: false,
+      dryRun,
+      postSlug,
+      recipientCount: subscribers.length,
+      sentCount: 0,
+      failedCount: 0,
+      message: 'SES sender email is not configured; notification was not reserved or sent.',
+    });
+  }
+
+  try {
+    await reserveNotificationSend({
+      postSlug,
+      status: 'sending',
+      dryRun: 'false',
+      startedAt: sendStartedAt,
+      recipientCount: String(subscribers.length),
+      sentCount: '0',
+      failedCount: '0',
+    });
+  } catch (error) {
+    if (error?.name === 'ConditionalCheckFailedException') {
+      return internalResponse(409, {
+        success: false,
+        duplicate: true,
+        postSlug,
+        message: `Notification for "${postSlug}" was already sent or is already in progress.`,
+      });
+    }
+
+    throw error;
+  }
+
+  let sentCount = 0;
+  let failedCount = 0;
+
+  for (const subscriber of subscribers) {
+    try {
+      await sendBlogNotification(post, subscriber);
+      sentCount += 1;
+    } catch (error) {
+      failedCount += 1;
+      console.error('Failed to send blog post notification.', {
+        errorName: error?.name,
+        postSlug,
+        subscriberId: subscriber.subscriberId,
+      });
+    }
+  }
+
+  const status = failedCount > 0 ? 'failed' : 'sent';
+
+  await completeNotificationSend(postSlug, {
+    status,
+    completedAt: now().toISOString(),
+    recipientCount: String(subscribers.length),
+    sentCount: String(sentCount),
+    failedCount: String(failedCount),
+  });
+
+  console.info('Blog post notification send completed.', {
+    postSlug,
+    recipientCount: subscribers.length,
+    sentCount,
+    failedCount,
+  });
+
+  return internalResponse(200, {
+    success: failedCount === 0,
+    dryRun,
+    postSlug,
+    recipientCount: subscribers.length,
+    sentCount,
+    failedCount,
+    message: `Sent ${sentCount} blog notification(s) for ${post.title}; ${failedCount} failed.`,
+  });
 }
 
 async function findExistingSubscriber(emailHash, findSubscriberByEmailHash) {
@@ -476,6 +608,82 @@ async function unsubscribeSubscriberInDynamoDb(emailHash, unsubscribedAt) {
   );
 }
 
+async function listActiveSubscribersFromDynamoDb() {
+  const tableName = getTableName();
+  const { DynamoDBClient, ScanCommand } = await loadDynamoDbClient();
+  const client = dynamoClient ?? new DynamoDBClient({});
+  dynamoClient = client;
+  const subscribers = [];
+  let exclusiveStartKey;
+
+  do {
+    const response = await client.send(
+      new ScanCommand({
+        TableName: tableName,
+        ExclusiveStartKey: exclusiveStartKey,
+        FilterExpression: '#status = :active AND attribute_exists(unsubscribeToken)',
+        ExpressionAttributeNames: {
+          '#status': 'status',
+        },
+        ExpressionAttributeValues: {
+          ':active': { S: 'active' },
+        },
+      }),
+    );
+
+    for (const item of response.Items || []) {
+      subscribers.push(fromDynamoDbItem(item));
+    }
+
+    exclusiveStartKey = response.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+
+  return subscribers;
+}
+
+async function reserveNotificationSendInDynamoDb(item) {
+  const tableName = getNotificationSendsTableName();
+  const { DynamoDBClient, PutItemCommand } = await loadDynamoDbClient();
+  const client = dynamoClient ?? new DynamoDBClient({});
+  dynamoClient = client;
+
+  await client.send(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: toDynamoDbItem(item),
+      ConditionExpression: 'attribute_not_exists(postSlug)',
+    }),
+  );
+}
+
+async function completeNotificationSendInDynamoDb(postSlug, values) {
+  const tableName = getNotificationSendsTableName();
+  const { DynamoDBClient, UpdateItemCommand } = await loadDynamoDbClient();
+  const client = dynamoClient ?? new DynamoDBClient({});
+  dynamoClient = client;
+
+  await client.send(
+    new UpdateItemCommand({
+      TableName: tableName,
+      Key: {
+        postSlug: { S: postSlug },
+      },
+      UpdateExpression:
+        'SET #status = :status, completedAt = :completedAt, recipientCount = :recipientCount, sentCount = :sentCount, failedCount = :failedCount',
+      ExpressionAttributeNames: {
+        '#status': 'status',
+      },
+      ExpressionAttributeValues: {
+        ':status': { S: values.status },
+        ':completedAt': { S: values.completedAt },
+        ':recipientCount': { S: values.recipientCount },
+        ':sentCount': { S: values.sentCount },
+        ':failedCount': { S: values.failedCount },
+      },
+    }),
+  );
+}
+
 async function sendConfirmationEmail(subscriber, confirmationToken) {
   const senderEmail = process.env.SES_SENDER_EMAIL;
 
@@ -505,6 +713,39 @@ async function sendConfirmationEmail(subscriber, confirmationToken) {
           Text: {
             Charset: 'UTF-8',
             Data: formatConfirmationEmail(confirmationToken),
+          },
+        },
+      },
+    }),
+  );
+}
+
+async function sendBlogNotificationEmail(post, subscriber) {
+  const senderEmail = process.env.SES_SENDER_EMAIL;
+
+  if (!senderEmail) {
+    throw new Error('Missing SES_SENDER_EMAIL');
+  }
+
+  const { SESClient, SendEmailCommand } = await loadSesClient();
+  const client = sesClient ?? new SESClient({});
+  sesClient = client;
+
+  await client.send(
+    new SendEmailCommand({
+      Source: senderEmail,
+      Destination: {
+        ToAddresses: [subscriber.emailNormalized],
+      },
+      Message: {
+        Subject: {
+          Charset: 'UTF-8',
+          Data: `New Drake's Food post: ${post.title}`,
+        },
+        Body: {
+          Text: {
+            Charset: 'UTF-8',
+            Data: formatBlogNotificationEmail(post, subscriber),
           },
         },
       },
@@ -542,6 +783,16 @@ function getTableName() {
   return tableName;
 }
 
+function getNotificationSendsTableName() {
+  const tableName = process.env.BLOG_NOTIFICATION_SENDS_TABLE_NAME;
+
+  if (!tableName) {
+    throw new Error('Missing BLOG_NOTIFICATION_SENDS_TABLE_NAME');
+  }
+
+  return tableName;
+}
+
 function getSiteUrl() {
   return (process.env.BLOG_SUBSCRIPTIONS_SITE_URL || 'https://drakesfood.com').replace(/\/+$/, '');
 }
@@ -563,11 +814,32 @@ function formatConfirmationEmail(confirmationToken) {
   ].join('\n');
 }
 
+function formatBlogNotificationEmail(post, subscriber) {
+  const siteUrl = getSiteUrl();
+  const postUrl = `${siteUrl}${post.path}`;
+  const unsubscribeUrl = `${getApiBaseUrl()}/blog-subscriptions/unsubscribe?token=${encodeURIComponent(subscriber.unsubscribeToken)}`;
+
+  return [
+    `New on Drake's Food: ${post.title}`,
+    '',
+    post.summary,
+    '',
+    `Read it here: ${postUrl}`,
+    '',
+    'Want fewer emails? You can unsubscribe here:',
+    unsubscribeUrl,
+  ].join('\n');
+}
+
 function toDynamoDbItem(item) {
   const dynamoItem = {};
 
   for (const [key, value] of Object.entries(item)) {
-    if (value !== undefined && value !== '') {
+    if (typeof value === 'number') {
+      dynamoItem[key] = { N: String(value) };
+    } else if (typeof value === 'boolean') {
+      dynamoItem[key] = { BOOL: value };
+    } else if (value !== undefined && value !== '') {
       dynamoItem[key] = { S: value };
     }
   }
@@ -576,7 +848,7 @@ function toDynamoDbItem(item) {
 }
 
 function fromDynamoDbItem(item) {
-  return Object.fromEntries(Object.entries(item).map(([key, value]) => [key, value.S ?? '']));
+  return Object.fromEntries(Object.entries(item).map(([key, value]) => [key, value.S ?? value.N ?? value.BOOL ?? '']));
 }
 
 function hashValue(value) {
@@ -594,6 +866,13 @@ function jsonResponse(statusCode, body) {
       'content-type': 'application/json',
     },
     body: JSON.stringify(body),
+  };
+}
+
+function internalResponse(statusCode, body) {
+  return {
+    statusCode,
+    ...body,
   };
 }
 

--- a/infra/lambda/blog-subscriptions/index.mjs
+++ b/infra/lambda/blog-subscriptions/index.mjs
@@ -6,6 +6,8 @@ const CONFIRMATION_SUCCESS_REDIRECT = '/blog?subscription=confirmed';
 const CONFIRMATION_FAILURE_REDIRECT = '/blog?subscription=invalid';
 const UNSUBSCRIBE_SUCCESS_REDIRECT = '/blog?subscription=unsubscribed';
 const DEFAULT_MAX_BODY_BYTES = 8 * 1024;
+const DEFAULT_NOTIFICATION_BATCH_SIZE = 5;
+const DEFAULT_NOTIFICATION_MAX_RECIPIENTS = 50;
 const EMAIL_LIMIT = 254;
 
 let dynamoClient;
@@ -286,6 +288,8 @@ async function sendBlogPostNotification(event, { now, getBlogPost, listActiveSub
 
   const subscribers = await listActiveSubscribers();
   const sendStartedAt = now().toISOString();
+  const maxRecipients = getNotificationMaxRecipients();
+  const overRecipientLimit = subscribers.length > maxRecipients;
 
   if (dryRun) {
     return internalResponse(200, {
@@ -293,9 +297,26 @@ async function sendBlogPostNotification(event, { now, getBlogPost, listActiveSub
       dryRun,
       postSlug,
       recipientCount: subscribers.length,
+      maxRecipients,
+      overRecipientLimit,
       sentCount: 0,
       failedCount: 0,
-      message: `Dry run found ${subscribers.length} active subscriber(s) for ${post.title}.`,
+      message: overRecipientLimit
+        ? `Dry run found ${subscribers.length} active subscriber(s), which exceeds the V1 safety cap of ${maxRecipients}. Real send will be blocked.`
+        : `Dry run found ${subscribers.length} active subscriber(s) for ${post.title}.`,
+    });
+  }
+
+  if (overRecipientLimit) {
+    return internalResponse(400, {
+      success: false,
+      dryRun,
+      postSlug,
+      recipientCount: subscribers.length,
+      maxRecipients,
+      sentCount: 0,
+      failedCount: 0,
+      message: `Real send blocked because ${subscribers.length} active subscriber(s) exceeds the V1 safety cap of ${maxRecipients}.`,
     });
   }
 
@@ -337,14 +358,20 @@ async function sendBlogPostNotification(event, { now, getBlogPost, listActiveSub
   let sentCount = 0;
   let failedCount = 0;
 
-  for (const subscriber of subscribers) {
-    try {
-      await sendBlogNotification(post, subscriber);
-      sentCount += 1;
-    } catch (error) {
+  for (const subscriberBatch of chunkArray(subscribers, DEFAULT_NOTIFICATION_BATCH_SIZE)) {
+    const results = await Promise.allSettled(subscriberBatch.map((subscriber) => sendBlogNotification(post, subscriber)));
+
+    for (const [index, result] of results.entries()) {
+      const subscriber = subscriberBatch[index];
+
+      if (result.status === 'fulfilled') {
+        sentCount += 1;
+        continue;
+      }
+
       failedCount += 1;
       console.error('Failed to send blog post notification.', {
-        errorName: error?.name,
+        errorName: result.reason?.name,
         postSlug,
         subscriberId: subscriber.subscriberId,
       });
@@ -455,6 +482,12 @@ function getMaxBodyBytes() {
   const configuredLimit = Number.parseInt(process.env.BLOG_SUBSCRIPTIONS_MAX_BODY_BYTES || '', 10);
 
   return Number.isFinite(configuredLimit) && configuredLimit > 0 ? configuredLimit : DEFAULT_MAX_BODY_BYTES;
+}
+
+function getNotificationMaxRecipients() {
+  const configuredLimit = Number.parseInt(process.env.BLOG_NOTIFICATION_MAX_RECIPIENTS || '', 10);
+
+  return Number.isFinite(configuredLimit) && configuredLimit > 0 ? configuredLimit : DEFAULT_NOTIFICATION_MAX_RECIPIENTS;
 }
 
 function normalizeSignupBody(body) {
@@ -952,6 +985,16 @@ function escapeHtml(value) {
 
 function escapeAttribute(value) {
   return escapeHtml(value);
+}
+
+function chunkArray(values, size) {
+  const chunks = [];
+
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size));
+  }
+
+  return chunks;
 }
 
 class RequestBodyTooLargeError extends Error {}

--- a/infra/lambda/blog-subscriptions/index.test.mjs
+++ b/infra/lambda/blog-subscriptions/index.test.mjs
@@ -444,3 +444,163 @@ test('unsubscribe GET for already unsubscribed reader returns complete page', as
   assert.match(response.body, /You are unsubscribed/);
   delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
 });
+
+test('dry run reports active recipient count without reserving or sending', async () => {
+  const reservations = [];
+  const notifications = [];
+  const handler = createHandler({
+    getBlogPost: () => ({
+      slug: 'pizza-night',
+      title: 'Pizza Night',
+      summary: 'A crispy backyard pizza experiment.',
+      path: '/blog/pizza-night',
+    }),
+    listActiveSubscribers: async () => [
+      { subscriberId: 'subscriber-1', emailNormalized: 'one@example.com', unsubscribeToken: 'token-1' },
+      { subscriberId: 'subscriber-2', emailNormalized: 'two@example.com', unsubscribeToken: 'token-2' },
+    ],
+    reserveNotificationSend: async (item) => reservations.push(item),
+    sendBlogNotification: async (post, subscriber) => notifications.push({ post, subscriber }),
+  });
+
+  const response = await handler({ action: 'sendBlogPostNotification', postSlug: 'pizza-night', dryRun: true });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.success, true);
+  assert.equal(response.dryRun, true);
+  assert.equal(response.recipientCount, 2);
+  assert.equal(response.sentCount, 0);
+  assert.equal(response.failedCount, 0);
+  assert.deepEqual(reservations, []);
+  assert.deepEqual(notifications, []);
+});
+
+test('real send reserves post slug and sends to active subscribers', async () => {
+  const reservations = [];
+  const completions = [];
+  const notifications = [];
+  const post = {
+    slug: 'pizza-night',
+    title: 'Pizza Night',
+    summary: 'A crispy backyard pizza experiment.',
+    path: '/blog/pizza-night',
+  };
+  const handler = createHandler({
+    now: () => fixedDate,
+    getBlogPost: () => post,
+    listActiveSubscribers: async () => [
+      { subscriberId: 'subscriber-1', emailNormalized: 'one@example.com', unsubscribeToken: 'token-1' },
+      { subscriberId: 'subscriber-2', emailNormalized: 'two@example.com', unsubscribeToken: 'token-2' },
+    ],
+    reserveNotificationSend: async (item) => reservations.push(item),
+    completeNotificationSend: async (postSlug, values) => completions.push({ postSlug, values }),
+    sendBlogNotification: async (sentPost, subscriber) => notifications.push({ post: sentPost, subscriber }),
+  });
+
+  const response = await handler({ action: 'sendBlogPostNotification', postSlug: 'pizza-night', dryRun: false });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.success, true);
+  assert.deepEqual(reservations, [
+    {
+      postSlug: 'pizza-night',
+      status: 'sending',
+      dryRun: 'false',
+      startedAt: '2026-05-09T12:00:00.000Z',
+      recipientCount: '2',
+      sentCount: '0',
+      failedCount: '0',
+    },
+  ]);
+  assert.equal(notifications.length, 2);
+  assert.equal(notifications[0].subscriber.unsubscribeToken, 'token-1');
+  assert.deepEqual(completions, [
+    {
+      postSlug: 'pizza-night',
+      values: {
+        status: 'sent',
+        completedAt: '2026-05-09T12:00:00.000Z',
+        recipientCount: '2',
+        sentCount: '2',
+        failedCount: '0',
+      },
+    },
+  ]);
+});
+
+test('duplicate real send is blocked before sending', async () => {
+  const notifications = [];
+  const handler = createHandler({
+    getBlogPost: () => ({ slug: 'pizza-night', title: 'Pizza Night', summary: 'A crispy backyard pizza experiment.', path: '/blog/pizza-night' }),
+    listActiveSubscribers: async () => [{ subscriberId: 'subscriber-1', emailNormalized: 'one@example.com', unsubscribeToken: 'token-1' }],
+    reserveNotificationSend: async () => {
+      const error = new Error('Duplicate');
+      error.name = 'ConditionalCheckFailedException';
+      throw error;
+    },
+    sendBlogNotification: async (post, subscriber) => notifications.push({ post, subscriber }),
+  });
+
+  const response = await handler({ action: 'sendBlogPostNotification', postSlug: 'pizza-night', dryRun: false });
+
+  assert.equal(response.statusCode, 409);
+  assert.equal(response.success, false);
+  assert.equal(response.duplicate, true);
+  assert.deepEqual(notifications, []);
+});
+
+test('send action counts subscriber send failures without exposing email addresses', async () => {
+  const completions = [];
+  const handler = createHandler({
+    now: () => fixedDate,
+    getBlogPost: () => ({ slug: 'pizza-night', title: 'Pizza Night', summary: 'A crispy backyard pizza experiment.', path: '/blog/pizza-night' }),
+    listActiveSubscribers: async () => [
+      { subscriberId: 'subscriber-1', emailNormalized: 'one@example.com', unsubscribeToken: 'token-1' },
+      { subscriberId: 'subscriber-2', emailNormalized: 'two@example.com', unsubscribeToken: 'token-2' },
+    ],
+    reserveNotificationSend: async () => undefined,
+    completeNotificationSend: async (postSlug, values) => completions.push({ postSlug, values }),
+    sendBlogNotification: async (_post, subscriber) => {
+      if (subscriber.subscriberId === 'subscriber-2') {
+        throw new Error('SES failed');
+      }
+    },
+  });
+
+  const response = await handler({ action: 'sendBlogPostNotification', postSlug: 'pizza-night', dryRun: false });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.success, false);
+  assert.equal(response.recipientCount, 2);
+  assert.equal(response.sentCount, 1);
+  assert.equal(response.failedCount, 1);
+  assert.equal(completions[0].values.status, 'failed');
+});
+
+test('send action rejects unknown post slug', async () => {
+  const handler = createHandler({
+    getBlogPost: () => undefined,
+  });
+
+  const response = await handler({ action: 'sendBlogPostNotification', postSlug: 'missing-post', dryRun: true });
+
+  assert.equal(response.statusCode, 404);
+  assert.equal(response.success, false);
+});
+
+test('default real send fails before reservation when SES sender is missing', async () => {
+  const reservations = [];
+  delete process.env.SES_SENDER_EMAIL;
+  const handler = createHandler({
+    getBlogPost: () => ({ slug: 'pizza-night', title: 'Pizza Night', summary: 'A crispy backyard pizza experiment.', path: '/blog/pizza-night' }),
+    listActiveSubscribers: async () => [{ subscriberId: 'subscriber-1', emailNormalized: 'one@example.com', unsubscribeToken: 'token-1' }],
+    reserveNotificationSend: async (item) => reservations.push(item),
+  });
+
+  const response = await handler({ action: 'sendBlogPostNotification', postSlug: 'pizza-night', dryRun: false });
+
+  assert.equal(response.statusCode, 500);
+  assert.equal(response.success, false);
+  assert.equal(response.recipientCount, 1);
+  assert.deepEqual(reservations, []);
+});

--- a/infra/lambda/blog-subscriptions/index.test.mjs
+++ b/infra/lambda/blog-subscriptions/index.test.mjs
@@ -469,10 +469,58 @@ test('dry run reports active recipient count without reserving or sending', asyn
   assert.equal(response.success, true);
   assert.equal(response.dryRun, true);
   assert.equal(response.recipientCount, 2);
+  assert.equal(response.maxRecipients, 50);
+  assert.equal(response.overRecipientLimit, false);
   assert.equal(response.sentCount, 0);
   assert.equal(response.failedCount, 0);
   assert.deepEqual(reservations, []);
   assert.deepEqual(notifications, []);
+});
+
+test('dry run reports when recipient count exceeds safety cap', async () => {
+  process.env.BLOG_NOTIFICATION_MAX_RECIPIENTS = '1';
+  const handler = createHandler({
+    getBlogPost: () => ({ slug: 'pizza-night', title: 'Pizza Night', summary: 'A crispy backyard pizza experiment.', path: '/blog/pizza-night' }),
+    listActiveSubscribers: async () => [
+      { subscriberId: 'subscriber-1', emailNormalized: 'one@example.com', unsubscribeToken: 'token-1' },
+      { subscriberId: 'subscriber-2', emailNormalized: 'two@example.com', unsubscribeToken: 'token-2' },
+    ],
+  });
+
+  const response = await handler({ action: 'sendBlogPostNotification', postSlug: 'pizza-night', dryRun: true });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.success, true);
+  assert.equal(response.recipientCount, 2);
+  assert.equal(response.maxRecipients, 1);
+  assert.equal(response.overRecipientLimit, true);
+  assert.match(response.message, /Real send will be blocked/);
+  delete process.env.BLOG_NOTIFICATION_MAX_RECIPIENTS;
+});
+
+test('real send over recipient cap aborts before reservation', async () => {
+  const reservations = [];
+  const notifications = [];
+  process.env.BLOG_NOTIFICATION_MAX_RECIPIENTS = '1';
+  const handler = createHandler({
+    getBlogPost: () => ({ slug: 'pizza-night', title: 'Pizza Night', summary: 'A crispy backyard pizza experiment.', path: '/blog/pizza-night' }),
+    listActiveSubscribers: async () => [
+      { subscriberId: 'subscriber-1', emailNormalized: 'one@example.com', unsubscribeToken: 'token-1' },
+      { subscriberId: 'subscriber-2', emailNormalized: 'two@example.com', unsubscribeToken: 'token-2' },
+    ],
+    reserveNotificationSend: async (item) => reservations.push(item),
+    sendBlogNotification: async (post, subscriber) => notifications.push({ post, subscriber }),
+  });
+
+  const response = await handler({ action: 'sendBlogPostNotification', postSlug: 'pizza-night', dryRun: false });
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.success, false);
+  assert.equal(response.recipientCount, 2);
+  assert.equal(response.maxRecipients, 1);
+  assert.deepEqual(reservations, []);
+  assert.deepEqual(notifications, []);
+  delete process.env.BLOG_NOTIFICATION_MAX_RECIPIENTS;
 });
 
 test('real send reserves post slug and sends to active subscribers', async () => {
@@ -526,6 +574,34 @@ test('real send reserves post slug and sends to active subscribers', async () =>
       },
     },
   ]);
+});
+
+test('real send uses bounded concurrent batches', async () => {
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const subscribers = Array.from({ length: 7 }, (_, index) => ({
+    subscriberId: `subscriber-${index}`,
+    emailNormalized: `reader-${index}@example.com`,
+    unsubscribeToken: `token-${index}`,
+  }));
+  const handler = createHandler({
+    getBlogPost: () => ({ slug: 'pizza-night', title: 'Pizza Night', summary: 'A crispy backyard pizza experiment.', path: '/blog/pizza-night' }),
+    listActiveSubscribers: async () => subscribers,
+    reserveNotificationSend: async () => undefined,
+    completeNotificationSend: async () => undefined,
+    sendBlogNotification: async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight -= 1;
+    },
+  });
+
+  const response = await handler({ action: 'sendBlogPostNotification', postSlug: 'pizza-night', dryRun: false });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.sentCount, 7);
+  assert.equal(maxInFlight, 5);
 });
 
 test('duplicate real send is blocked before sending', async () => {

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -47,3 +47,8 @@ output "blog_subscriptions_lambda_function_name" {
   description = "Lambda function that handles blog email subscriptions."
   value       = aws_lambda_function.blog_subscriptions.function_name
 }
+
+output "blog_notification_sends_table_name" {
+  description = "DynamoDB table used for blog post notification send tracking."
+  value       = aws_dynamodb_table.blog_notification_sends.name
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -162,6 +162,12 @@ variable "blog_subscriptions_table_name" {
   default     = "drakesfood-blog-subscribers"
 }
 
+variable "blog_notification_sends_table_name" {
+  description = "DynamoDB table name for tracking sent blog post notifications."
+  type        = string
+  default     = "drakesfood-blog-notification-sends"
+}
+
 variable "blog_subscriptions_throttling_burst_limit" {
   description = "API Gateway burst throttling limit for blog subscriptions."
   type        = number

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -138,6 +138,12 @@ variable "blog_subscriptions_max_body_bytes" {
   default     = 8192
 }
 
+variable "blog_notification_max_recipients" {
+  description = "Maximum active subscribers allowed for one synchronous blog notification send. Raise only after testing or replacing with a queued sender."
+  type        = number
+  default     = 50
+}
+
 variable "blog_subscriptions_ses_identity_arn" {
   description = "Optional SES identity ARN allowed to send blog subscription emails. Defaults to the domain identity for the active AWS account."
   type        = string


### PR DESCRIPTION
## Summary
- Adds an internal Lambda action for controlled blog post notification sends with dry-run support.
- Adds active subscriber filtering, unsubscribe links, send failure counting, and duplicate-send tracking by post slug.
- Adds a manual GitHub Actions workflow for dry-run/real sends and OpenTofu permissions/resources for send tracking and Lambda invocation.

Closes #84
Refs #85
Refs #88

## Validation
- `node --test infra/lambda/blog-subscriptions/index.test.mjs`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `tofu validate`
- `git diff --check`

## Visual Review
- Not applicable. This PR does not change public page layout or styling.

## Deployment Notes
- No AWS resources were applied by this PR.
- Apply OpenTofu before using the workflow so the notification send tracking table, Lambda package update, and GitHub Actions IAM permission exist.
- SES sender/domain verification and `blog_subscriptions_ses_sender_email` must be configured before real sends.
- Run the new `Send Blog Notification` workflow with `dry_run: true` before any real send.
- The workflow defaults to Lambda function `drakesfood-blog-subscriptions`; optionally set repo variable `BLOG_SUBSCRIPTIONS_LAMBDA_FUNCTION_NAME` from the OpenTofu output.

## Manual Follow-Up Before Real Sends
- Apply OpenTofu.
- Ensure `BLOG_SUBSCRIPTIONS_API_BASE_URL` is set and signup/confirm/unsubscribe have been smoke-tested.
- Verify SES is out of sandbox or recipients are verified as needed.