### PR TITLE
Add blog subscription admin alerts

### DIFF
--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -51,11 +51,12 @@
 - [x] Redesign homepage hero and primary calls-to-action — #55
 - [x] Add dedicated RecipeSensei teaser page — #59
 - [x] Add first recipe/story blog detail page
+- [x] Document blog email notification operations — #85
 
 ## 🔄 In Progress
 
 - [ ] Expand SEO, social sharing, sitemap, and robots metadata — #58
-- [ ] Document blog email notification operations — #85
+- [ ] Notify Drake when readers subscribe or unsubscribe — #88
 
 ## 📋 Remaining Tasks
 
@@ -138,7 +139,8 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - Blog email unsubscribe support is being added before new-post notification sending so every future notification can include a working unsubscribe link.
 - Blog post notification sending is being added as a manual GitHub Actions workflow with dry-run support, duplicate-send tracking, and unsubscribe links in every email.
 - Blog email operations documentation is being expanded into a setup, testing, sending, privacy, cost, and recovery runbook.
+- Optional blog subscription admin alerts are being added so Drake can be notified after confirmed subscriptions and unsubscribes without exposing subscriber emails in alert bodies.
 
 ## Last Updated
 
-May 9, 2026
+May 10, 2026

--- a/docs/blog-email-subscriptions.md
+++ b/docs/blog-email-subscriptions.md
@@ -19,6 +19,7 @@ Before accepting public subscribers or sending real notification emails:
 - Verify the SES sending identity for `drakesfood.com` or the configured sender address.
 - Confirm SES production access, or understand sandbox limits if still in sandbox.
 - Set `blog_subscriptions_ses_sender_email` locally for OpenTofu, for example `Drake's Food <updates@drakesfood.com>`.
+- Optionally set `blog_subscriptions_admin_recipient_email = "drakejrobert@gmail.com"` locally for admin alerts when readers confirm or unsubscribe.
 - Run `AWS_PROFILE=drakesfood tofu plan` from `infra/` and review the planned blog subscription resources.
 - Run `AWS_PROFILE=drakesfood tofu apply` only after the plan looks correct.
 - Set GitHub repository variable `BLOG_SUBSCRIPTIONS_API_BASE_URL` from `tofu output -raw blog_subscriptions_api_endpoint`.
@@ -113,9 +114,9 @@ Blog subscription infrastructure is defined in `infra/blog_subscriptions.tf`.
 The V1 architecture uses:
 
 - API Gateway HTTP API for `POST /blog-subscriptions`, `GET /blog-subscriptions/confirm`, `GET /blog-subscriptions/unsubscribe`, and `POST /blog-subscriptions/unsubscribe`.
-- Lambda for validation, honeypot handling, DynamoDB writes, SES confirmation emails, confirmation activation, unsubscribe handling, and controlled blog post notification sending.
+- Lambda for validation, honeypot handling, DynamoDB writes, SES confirmation emails, confirmation activation, unsubscribe handling, optional admin alerts, and controlled blog post notification sending.
 - DynamoDB for subscriber records and notification send tracking.
-- SES for confirmation emails and blog post notification emails.
+- SES for confirmation emails, optional admin alerts, and blog post notification emails.
 - CloudWatch Logs for API Gateway access logs and Lambda logs.
 - OpenTofu for resource management.
 
@@ -188,6 +189,22 @@ Run with `dry_run: true` first. Dry runs count active subscribers and do not sen
 
 Notification emails are sent only to subscribers with `status: active` and an `unsubscribeToken`. Pending and unsubscribed readers are excluded. Each email includes a post link and an unsubscribe link that lands on the unsubscribe confirmation page.
 
+## Admin Alerts
+
+Admin alerts are optional emails to Drake when a reader confirms a blog subscription or unsubscribes.
+
+Set `blog_subscriptions_admin_recipient_email` through a local `.tfvars` file or `-var` argument to enable them. Leave it blank to disable them. The Lambda receives this as `BLOG_SUBSCRIPTIONS_ADMIN_RECIPIENT_EMAIL`.
+
+Recommended V1 value:
+
+```hcl
+blog_subscriptions_admin_recipient_email = "drakejrobert@gmail.com"
+```
+
+Admin alerts use the same configured SES sender as the reader-facing emails. If SES is still in sandbox, `drakejrobert@gmail.com` must be verified as an SES recipient before alerts can be delivered.
+
+Admin alert failures are logged but do not block the reader-facing confirmation or unsubscribe success redirect. Alert bodies intentionally omit the subscriber email address and include only operational metadata such as event type, subscriber ID, timestamp, and source site.
+
 ## Privacy
 
 Subscriber email addresses are private data.
@@ -195,6 +212,7 @@ Subscriber email addresses are private data.
 - Do not commit subscriber exports.
 - Do not add subscriber emails to GitHub issues, logs, screenshots, or docs.
 - Prefer logging `subscriberId` and error names instead of raw email addresses or tokens.
+- Admin subscription alerts intentionally omit raw subscriber email addresses.
 - Confirmation tokens are stored only as SHA-256 hashes.
 - Unsubscribe tokens are private bearer-token data. Store them only in DynamoDB, use them only for notification email links, and do not log them.
 - Every future notification email must include the subscriber's unsubscribe link. That link should use `GET /blog-subscriptions/unsubscribe?token=<unsubscribe-token>` so the reader lands on the confirmation page before any state change.
@@ -208,6 +226,7 @@ Before production confirmations or notification emails can work:
 - Verify `drakesfood.com` as an SES sending identity, or provide a specific verified identity ARN.
 - If the AWS account is still in the SES sandbox, verified recipient limitations will apply.
 - Set `blog_subscriptions_ses_sender_email` through a local `.tfvars` file or `-var` argument.
+- Set `blog_subscriptions_admin_recipient_email` only if Drake should receive confirm/unsubscribe admin alerts.
 - Set `blog_subscriptions_ses_identity_arn` only if the sending identity is not the default `drakesfood.com` domain identity in the active AWS account.
 
 If SES is still in sandbox, signup confirmations and blog notifications can only be sent to verified recipient addresses. Request SES production access before inviting public subscribers.
@@ -237,6 +256,7 @@ Useful variables for this feature are defined in `infra/variables.tf`:
 
 - `blog_subscriptions_api_name`
 - `blog_subscriptions_allowed_origins`
+- `blog_subscriptions_admin_recipient_email`
 - `blog_subscriptions_lambda_function_name`
 - `blog_subscriptions_log_retention_days`
 - `blog_subscriptions_max_body_bytes`
@@ -379,5 +399,4 @@ When publishing a new blog post that should support email notification:
 
 ## Follow-Up Work
 
-- #88 can optionally notify Drake when readers subscribe or unsubscribe.
 - A future queued sender can replace the V1 synchronous sender if the subscriber list grows beyond the configured cap.

--- a/infra/README.md
+++ b/infra/README.md
@@ -45,14 +45,14 @@ The blog subscription backend is defined as low-cost serverless infrastructure:
 
 - API Gateway HTTP API exposes `POST /blog-subscriptions`, `GET /blog-subscriptions/confirm`, `GET /blog-subscriptions/unsubscribe`, and `POST /blog-subscriptions/unsubscribe`.
 - CORS is restricted to `drakesfood.com`, `www.drakesfood.com`, and local Angular development by default.
-- Lambda receives the subscriber table name, notification send table name, source site, allowed origins, API base URL, site URL, and SES sender through environment variables.
+- Lambda receives the subscriber table name, notification send table name, source site, allowed origins, API base URL, site URL, optional admin alert recipient, and SES sender through environment variables.
 - DynamoDB stores subscriber records by `emailHash` so each normalized email has one record, keeps private unsubscribe tokens for notification links, uses lookup indexes for confirmation and unsubscribe token hashes, and tracks notification sends by `postSlug`.
-- SES sends plain-text confirmation emails and controlled blog post notification emails. Notification emails include an unsubscribe link.
+- SES sends plain-text confirmation emails, optional admin alerts, and controlled blog post notification emails. Notification emails include an unsubscribe link.
 - Blog notification sending is capped by `blog_notification_max_recipients` for the V1 synchronous sender and runs in small batches to reduce timeout risk.
 - CloudWatch log groups use the configured retention period.
 - API Gateway throttling defaults to 10 burst requests and 5 sustained requests per second.
 
-The Lambda source lives at `lambda/blog-subscriptions/index.mjs`. It validates signup requests, handles honeypot submissions without storing or emailing them, stores pending subscribers in DynamoDB, sends SES confirmation emails when a sender is configured, activates pending subscribers from confirmation links, serves a read-only unsubscribe confirmation page for email links, marks subscribers unsubscribed only after the confirmation page submits a POST request, and sends blog post notifications from an internal GitHub Actions-triggered event.
+The Lambda source lives at `lambda/blog-subscriptions/index.mjs`. It validates signup requests, handles honeypot submissions without storing or emailing them, stores pending subscribers in DynamoDB, sends SES confirmation emails when a sender is configured, activates pending subscribers from confirmation links, optionally emails Drake after successful confirmations or unsubscribes, serves a read-only unsubscribe confirmation page for email links, marks subscribers unsubscribed only after the confirmation page submits a POST request, and sends blog post notifications from an internal GitHub Actions-triggered event.
 
 The Lambda request body limit defaults to `8192` bytes and can be adjusted with `blog_subscriptions_max_body_bytes` if needed.
 
@@ -63,9 +63,10 @@ Before applying blog subscription infrastructure for production, set these value
 ```hcl
 blog_subscriptions_ses_identity_arn = "arn:aws:ses:us-east-2:<account-id>:identity/drakesfood.com"
 blog_subscriptions_ses_sender_email = "Drake's Food <updates@drakesfood.com>"
+blog_subscriptions_admin_recipient_email = "drakejrobert@gmail.com"
 ```
 
-Do not commit real private email addresses or account-specific values unless they are intentionally public. The SES sender identity must be verified before confirmation emails can work. If the SES sender is missing, accepted signups are still stored but confirmation email is skipped and logged.
+Do not commit real private email addresses or account-specific values unless they are intentionally public. The SES sender identity must be verified before confirmation emails can work. If the SES sender is missing, accepted signups are still stored but confirmation email is skipped and logged. The admin recipient is optional; leave `blog_subscriptions_admin_recipient_email` blank to disable confirm/unsubscribe alerts. If SES is still in sandbox, the admin recipient must also be verified in SES.
 
 After apply, get the API endpoint for frontend configuration:
 

--- a/infra/blog_subscriptions.tf
+++ b/infra/blog_subscriptions.tf
@@ -172,15 +172,16 @@ resource "aws_lambda_function" "blog_subscriptions" {
 
   environment {
     variables = {
-      BLOG_NOTIFICATION_MAX_RECIPIENTS   = tostring(var.blog_notification_max_recipients)
-      ALLOWED_ORIGINS                    = join(",", var.blog_subscriptions_allowed_origins)
-      BLOG_NOTIFICATION_SENDS_TABLE_NAME = aws_dynamodb_table.blog_notification_sends.name
-      BLOG_SUBSCRIPTIONS_API_BASE_URL    = aws_apigatewayv2_api.blog_subscriptions.api_endpoint
-      BLOG_SUBSCRIPTIONS_MAX_BODY_BYTES  = tostring(var.blog_subscriptions_max_body_bytes)
-      BLOG_SUBSCRIPTIONS_SITE_URL        = "https://${var.domain_name}"
-      BLOG_SUBSCRIPTIONS_SOURCE_SITE     = var.blog_subscriptions_source_site
-      BLOG_SUBSCRIPTIONS_TABLE_NAME      = aws_dynamodb_table.blog_subscribers.name
-      SES_SENDER_EMAIL                   = var.blog_subscriptions_ses_sender_email
+      BLOG_NOTIFICATION_MAX_RECIPIENTS         = tostring(var.blog_notification_max_recipients)
+      ALLOWED_ORIGINS                          = join(",", var.blog_subscriptions_allowed_origins)
+      BLOG_NOTIFICATION_SENDS_TABLE_NAME       = aws_dynamodb_table.blog_notification_sends.name
+      BLOG_SUBSCRIPTIONS_ADMIN_RECIPIENT_EMAIL = var.blog_subscriptions_admin_recipient_email
+      BLOG_SUBSCRIPTIONS_API_BASE_URL          = aws_apigatewayv2_api.blog_subscriptions.api_endpoint
+      BLOG_SUBSCRIPTIONS_MAX_BODY_BYTES        = tostring(var.blog_subscriptions_max_body_bytes)
+      BLOG_SUBSCRIPTIONS_SITE_URL              = "https://${var.domain_name}"
+      BLOG_SUBSCRIPTIONS_SOURCE_SITE           = var.blog_subscriptions_source_site
+      BLOG_SUBSCRIPTIONS_TABLE_NAME            = aws_dynamodb_table.blog_subscribers.name
+      SES_SENDER_EMAIL                         = var.blog_subscriptions_ses_sender_email
     }
   }
 

--- a/infra/lambda/blog-subscriptions/index.mjs
+++ b/infra/lambda/blog-subscriptions/index.mjs
@@ -26,6 +26,7 @@ export const createHandler = ({
   activateSubscriber = activateSubscriberInDynamoDb,
   unsubscribeSubscriber = unsubscribeSubscriberInDynamoDb,
   sendConfirmation = sendConfirmationEmail,
+  sendAdminNotification = sendAdminNotificationEmail,
   getBlogPost = getBlogNotificationPost,
   listActiveSubscribers = listActiveSubscribersFromDynamoDb,
   reserveNotificationSend = reserveNotificationSendInDynamoDb,
@@ -47,7 +48,7 @@ export const createHandler = ({
   const path = getPath(event);
 
   if (method === 'GET' && path.endsWith('/blog-subscriptions/confirm')) {
-    return confirmSubscription(event, { now, findSubscriberByConfirmationTokenHash, activateSubscriber });
+    return confirmSubscription(event, { now, findSubscriberByConfirmationTokenHash, activateSubscriber, sendAdminNotification });
   }
 
   if (method === 'GET' && path.endsWith('/blog-subscriptions/unsubscribe')) {
@@ -55,7 +56,7 @@ export const createHandler = ({
   }
 
   if (method === 'POST' && path.endsWith('/blog-subscriptions/unsubscribe')) {
-    return unsubscribeFromBlog(event, { now, findSubscriberByUnsubscribeTokenHash, unsubscribeSubscriber });
+    return unsubscribeFromBlog(event, { now, findSubscriberByUnsubscribeTokenHash, unsubscribeSubscriber, sendAdminNotification });
   }
 
   if (method !== 'POST') {
@@ -182,7 +183,7 @@ export const createHandler = ({
 
 export const handler = createHandler();
 
-async function confirmSubscription(event, { now, findSubscriberByConfirmationTokenHash, activateSubscriber }) {
+async function confirmSubscription(event, { now, findSubscriberByConfirmationTokenHash, activateSubscriber, sendAdminNotification }) {
   const token = getQueryStringParameter(event, 'token');
   const siteUrl = getSiteUrl();
 
@@ -198,7 +199,9 @@ async function confirmSubscription(event, { now, findSubscriberByConfirmationTok
   }
 
   try {
-    await activateSubscriber(subscriber.emailHash, now().toISOString());
+    const confirmedAt = now().toISOString();
+    await activateSubscriber(subscriber.emailHash, confirmedAt);
+    await trySendAdminNotification(sendAdminNotification, 'confirmed', subscriber, confirmedAt);
   } catch (error) {
     console.error('Failed to confirm blog subscriber.', {
       errorName: error?.name,
@@ -233,7 +236,7 @@ async function renderUnsubscribeConfirmation(event, { findSubscriberByUnsubscrib
   return htmlResponse(200, buildUnsubscribeConfirmationHtml(token, siteUrl));
 }
 
-async function unsubscribeFromBlog(event, { now, findSubscriberByUnsubscribeTokenHash, unsubscribeSubscriber }) {
+async function unsubscribeFromBlog(event, { now, findSubscriberByUnsubscribeTokenHash, unsubscribeSubscriber, sendAdminNotification }) {
   const token = getQueryStringParameter(event, 'token');
   const siteUrl = getSiteUrl();
 
@@ -253,7 +256,9 @@ async function unsubscribeFromBlog(event, { now, findSubscriberByUnsubscribeToke
   }
 
   try {
-    await unsubscribeSubscriber(subscriber.emailHash, now().toISOString());
+    const unsubscribedAt = now().toISOString();
+    await unsubscribeSubscriber(subscriber.emailHash, unsubscribedAt);
+    await trySendAdminNotification(sendAdminNotification, 'unsubscribed', subscriber, unsubscribedAt);
   } catch (error) {
     console.error('Failed to unsubscribe blog subscriber.', {
       errorName: error?.name,
@@ -786,6 +791,57 @@ async function sendBlogNotificationEmail(post, subscriber) {
   );
 }
 
+async function sendAdminNotificationEmail(eventType, subscriber, timestamp) {
+  const recipientEmail = process.env.BLOG_SUBSCRIPTIONS_ADMIN_RECIPIENT_EMAIL;
+
+  if (!recipientEmail) {
+    return;
+  }
+
+  const senderEmail = process.env.SES_SENDER_EMAIL;
+
+  if (!senderEmail) {
+    throw new Error('Missing SES_SENDER_EMAIL');
+  }
+
+  const { SESClient, SendEmailCommand } = await loadSesClient();
+  const client = sesClient ?? new SESClient({});
+  sesClient = client;
+
+  await client.send(
+    new SendEmailCommand({
+      Source: senderEmail,
+      Destination: {
+        ToAddresses: [recipientEmail],
+      },
+      Message: {
+        Subject: {
+          Charset: 'UTF-8',
+          Data: `Drakesfood Blog Subscription Alert: ${eventType}`,
+        },
+        Body: {
+          Text: {
+            Charset: 'UTF-8',
+            Data: formatAdminNotificationEmail(eventType, subscriber, timestamp),
+          },
+        },
+      },
+    }),
+  );
+}
+
+async function trySendAdminNotification(sendAdminNotification, eventType, subscriber, timestamp) {
+  try {
+    await sendAdminNotification(eventType, subscriber, timestamp);
+  } catch (error) {
+    console.error('Failed to send blog subscription admin notification.', {
+      errorName: error?.name,
+      eventType,
+      subscriberId: subscriber.subscriberId,
+    });
+  }
+}
+
 async function loadDynamoDbClient() {
   if (dynamoModule) {
     return dynamoModule;
@@ -861,6 +917,18 @@ function formatBlogNotificationEmail(post, subscriber) {
     '',
     'Want fewer emails? You can unsubscribe here:',
     unsubscribeUrl,
+  ].join('\n');
+}
+
+function formatAdminNotificationEmail(eventType, subscriber, timestamp) {
+  return [
+    `Blog subscription event: ${eventType}`,
+    '',
+    `Subscriber ID: ${subscriber.subscriberId || 'unknown'}`,
+    `Timestamp: ${timestamp}`,
+    `Source: ${subscriber.source || process.env.BLOG_SUBSCRIPTIONS_SOURCE_SITE || 'drakesfood.com'}`,
+    '',
+    'Subscriber email is intentionally omitted from this admin alert for privacy.',
   ].join('\n');
 }
 

--- a/infra/lambda/blog-subscriptions/index.test.mjs
+++ b/infra/lambda/blog-subscriptions/index.test.mjs
@@ -334,6 +334,92 @@ test('valid confirmation activates a pending subscriber and redirects to success
   delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
 });
 
+test('valid confirmation sends admin notification when configured', async () => {
+  const adminNotifications = [];
+  const emailHash = hash('fan@example.com');
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    now: () => fixedDate,
+    findSubscriberByConfirmationTokenHash: async (confirmationTokenHash) => ({
+      subscriberId: 'subscriber-123',
+      emailHash,
+      confirmationTokenHash,
+      status: 'pending',
+      source: 'drakesfood.com',
+    }),
+    activateSubscriber: async () => undefined,
+    sendAdminNotification: async (eventType, subscriber, timestamp) => adminNotifications.push({ eventType, subscriber, timestamp }),
+  });
+
+  const response = await handler(createConfirmEvent('confirm-token'));
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=confirmed');
+  assert.deepEqual(adminNotifications, [
+    {
+      eventType: 'confirmed',
+      subscriber: {
+        subscriberId: 'subscriber-123',
+        emailHash,
+        confirmationTokenHash: hash('confirm-token'),
+        status: 'pending',
+        source: 'drakesfood.com',
+      },
+      timestamp: '2026-05-09T12:00:00.000Z',
+    },
+  ]);
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
+test('blank admin recipient skips default confirmation admin notification', async () => {
+  const emailHash = hash('fan@example.com');
+  delete process.env.BLOG_SUBSCRIPTIONS_ADMIN_RECIPIENT_EMAIL;
+  delete process.env.SES_SENDER_EMAIL;
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    now: () => fixedDate,
+    findSubscriberByConfirmationTokenHash: async (confirmationTokenHash) => ({
+      subscriberId: 'subscriber-123',
+      emailHash,
+      confirmationTokenHash,
+      status: 'pending',
+    }),
+    activateSubscriber: async () => undefined,
+  });
+
+  const response = await handler(createConfirmEvent('confirm-token'));
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=confirmed');
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
+test('admin notification failure does not block confirmation success', async () => {
+  const activations = [];
+  const emailHash = hash('fan@example.com');
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    now: () => fixedDate,
+    findSubscriberByConfirmationTokenHash: async (confirmationTokenHash) => ({
+      subscriberId: 'subscriber-123',
+      emailHash,
+      confirmationTokenHash,
+      status: 'pending',
+    }),
+    activateSubscriber: async (activatedEmailHash, confirmedAt) => activations.push({ emailHash: activatedEmailHash, confirmedAt }),
+    sendAdminNotification: async () => {
+      throw new Error('SES failed');
+    },
+  });
+
+  const response = await handler(createConfirmEvent('confirm-token'));
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=confirmed');
+  assert.deepEqual(activations, [{ emailHash, confirmedAt: '2026-05-09T12:00:00.000Z' }]);
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
 test('invalid confirmation token redirects to failure', async () => {
   process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
   const handler = createHandler({
@@ -370,8 +456,72 @@ test('valid unsubscribe token marks subscriber unsubscribed and redirects to suc
   delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
 });
 
+test('valid unsubscribe sends admin notification when configured', async () => {
+  const adminNotifications = [];
+  const emailHash = hash('fan@example.com');
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    now: () => fixedDate,
+    findSubscriberByUnsubscribeTokenHash: async (unsubscribeTokenHash) => ({
+      subscriberId: 'subscriber-123',
+      emailHash,
+      unsubscribeTokenHash,
+      status: 'active',
+      source: 'drakesfood.com',
+    }),
+    unsubscribeSubscriber: async () => undefined,
+    sendAdminNotification: async (eventType, subscriber, timestamp) => adminNotifications.push({ eventType, subscriber, timestamp }),
+  });
+
+  const response = await handler(createUnsubscribeEvent('unsubscribe-token', 'POST'));
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=unsubscribed');
+  assert.deepEqual(adminNotifications, [
+    {
+      eventType: 'unsubscribed',
+      subscriber: {
+        subscriberId: 'subscriber-123',
+        emailHash,
+        unsubscribeTokenHash: hash('unsubscribe-token'),
+        status: 'active',
+        source: 'drakesfood.com',
+      },
+      timestamp: '2026-05-09T12:00:00.000Z',
+    },
+  ]);
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
+test('admin notification failure does not block unsubscribe success', async () => {
+  const unsubscribes = [];
+  const emailHash = hash('fan@example.com');
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    now: () => fixedDate,
+    findSubscriberByUnsubscribeTokenHash: async (unsubscribeTokenHash) => ({
+      subscriberId: 'subscriber-123',
+      emailHash,
+      unsubscribeTokenHash,
+      status: 'active',
+    }),
+    unsubscribeSubscriber: async (unsubscribedEmailHash, unsubscribedAt) => unsubscribes.push({ emailHash: unsubscribedEmailHash, unsubscribedAt }),
+    sendAdminNotification: async () => {
+      throw new Error('SES failed');
+    },
+  });
+
+  const response = await handler(createUnsubscribeEvent('unsubscribe-token', 'POST'));
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=unsubscribed');
+  assert.deepEqual(unsubscribes, [{ emailHash, unsubscribedAt: '2026-05-09T12:00:00.000Z' }]);
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
 test('already unsubscribed token redirects to success without another update', async () => {
   const unsubscribes = [];
+  const adminNotifications = [];
   process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
   const handler = createHandler({
     findSubscriberByUnsubscribeTokenHash: async () => ({
@@ -380,6 +530,7 @@ test('already unsubscribed token redirects to success without another update', a
       status: 'unsubscribed',
     }),
     unsubscribeSubscriber: async (emailHash) => unsubscribes.push(emailHash),
+    sendAdminNotification: async (eventType) => adminNotifications.push(eventType),
   });
 
   const response = await handler(createUnsubscribeEvent('unsubscribe-token', 'POST'));
@@ -387,6 +538,7 @@ test('already unsubscribed token redirects to success without another update', a
   assert.equal(response.statusCode, 302);
   assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=unsubscribed');
   assert.deepEqual(unsubscribes, []);
+  assert.deepEqual(adminNotifications, []);
   delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
 });
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -120,6 +120,12 @@ variable "blog_subscriptions_allowed_origins" {
   ]
 }
 
+variable "blog_subscriptions_admin_recipient_email" {
+  description = "Optional email address that receives admin alerts when readers confirm blog subscriptions or unsubscribe. Leave blank to disable alerts."
+  type        = string
+  default     = ""
+}
+
 variable "blog_subscriptions_lambda_function_name" {
   description = "Lambda function name for blog email subscriptions."
   type        = string


### PR DESCRIPTION
## Summary
- Adds optional SES admin alerts when readers confirm blog subscriptions or unsubscribe.
- Wires `blog_subscriptions_admin_recipient_email` through OpenTofu as `BLOG_SUBSCRIPTIONS_ADMIN_RECIPIENT_EMAIL`.
- Documents setup, SES sandbox verification, and privacy behavior; alert bodies omit raw subscriber email addresses.

Closes #88.

## Validation
- `node --test infra/lambda/blog-subscriptions/index.test.mjs`
- `tofu fmt -check`
- `tofu validate`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Manual Setup After Merge
- If SES is still in sandbox, verify `drakejrobert@gmail.com` as an SES recipient.
- Set `blog_subscriptions_admin_recipient_email = "drakejrobert@gmail.com"` in local OpenTofu variables.
- Run `AWS_PROFILE=drakesfood tofu plan` from `infra/` and review.
- Run `AWS_PROFILE=drakesfood tofu apply` from `infra/` when the plan looks correct.