### PR TITLE
Improve subscription confirmation copy

### DIFF
--- a/docs/blog-email-subscriptions.md
+++ b/docs/blog-email-subscriptions.md
@@ -77,7 +77,7 @@ Success response:
 ```json
 {
   "success": true,
-  "message": "If that email can be subscribed, a confirmation link is on the way."
+  "message": "If that email can be subscribed, a confirmation link is on the way. Check your junk or spam folder if you do not see it soon."
 }
 ```
 

--- a/infra/lambda/blog-subscriptions/index.mjs
+++ b/infra/lambda/blog-subscriptions/index.mjs
@@ -1,7 +1,7 @@
 import { createHash, randomBytes, randomUUID } from 'node:crypto';
 import { getBlogNotificationPost } from './blog-notification-posts.mjs';
 
-const SIGNUP_SUCCESS_MESSAGE = 'If that email can be subscribed, a confirmation link is on the way.';
+const SIGNUP_SUCCESS_MESSAGE = 'If that email can be subscribed, a confirmation link is on the way. Check your junk or spam folder if you do not see it soon.';
 const CONFIRMATION_SUCCESS_REDIRECT = '/blog?subscription=confirmed';
 const CONFIRMATION_FAILURE_REDIRECT = '/blog?subscription=invalid';
 const UNSUBSCRIBE_SUCCESS_REDIRECT = '/blog?subscription=unsubscribed';
@@ -895,6 +895,7 @@ function formatConfirmationEmail(confirmationToken) {
 
   return [
     "You're almost subscribed to Drake's Food blog emails.",
+    'You requested this confirmation from https://drakesfood.com.',
     '',
     'Confirm your subscription here:',
     confirmationUrl,

--- a/infra/lambda/blog-subscriptions/index.test.mjs
+++ b/infra/lambda/blog-subscriptions/index.test.mjs
@@ -77,7 +77,7 @@ test('stores a pending subscriber and sends a confirmation email', async () => {
   assert.equal(response.statusCode, 200);
   assert.deepEqual(parseResponse(response), {
     success: true,
-    message: 'If that email can be subscribed, a confirmation link is on the way.',
+    message: 'If that email can be subscribed, a confirmation link is on the way. Check your junk or spam folder if you do not see it soon.',
   });
   assert.deepEqual(savedSubscribers, [
     {
@@ -132,7 +132,7 @@ test('handles populated honeypot as generic success without saving', async () =>
   assert.equal(response.statusCode, 200);
   assert.deepEqual(parseResponse(response), {
     success: true,
-    message: 'If that email can be subscribed, a confirmation link is on the way.',
+    message: 'If that email can be subscribed, a confirmation link is on the way. Check your junk or spam folder if you do not see it soon.',
   });
   assert.deepEqual(savedSubscribers, []);
   assert.deepEqual(confirmations, []);
@@ -240,7 +240,7 @@ test('duplicate active signup returns generic success without resending confirma
   assert.equal(response.statusCode, 200);
   assert.deepEqual(parseResponse(response), {
     success: true,
-    message: 'If that email can be subscribed, a confirmation link is on the way.',
+    message: 'If that email can be subscribed, a confirmation link is on the way. Check your junk or spam folder if you do not see it soon.',
   });
   assert.deepEqual(saves, []);
   assert.deepEqual(confirmations, []);

--- a/src/app/components/blog-subscription/blog-subscription.component.html
+++ b/src/app/components/blog-subscription/blog-subscription.component.html
@@ -19,7 +19,7 @@
         placeholder="you@example.com"
         aria-describedby="blog-subscription-help blog-subscription-error"
       />
-      <p id="blog-subscription-help" class="field-help">Confirm your email before updates start arriving.</p>
+      <p id="blog-subscription-help" class="field-help">Confirm your email before updates start arriving. Check junk or spam if the link is slow.</p>
       @if (hasFieldError('email', 'required')) {
         <p id="blog-subscription-error" class="field-error">Please enter your email address.</p>
       } @else if (hasFieldError('email', 'email')) {

--- a/src/app/components/blog-subscription/blog-subscription.component.ts
+++ b/src/app/components/blog-subscription/blog-subscription.component.ts
@@ -4,6 +4,8 @@ import { BlogSubscriptionApiService, type BlogSubscriptionPayload } from '../../
 
 type SubscriptionStatus = 'idle' | 'submitting' | 'success' | 'error';
 
+const SIGNUP_SUCCESS_MESSAGE = 'If that email can be subscribed, a confirmation link is on the way. Check your junk or spam folder if you do not see it soon.';
+
 @Component({
   selector: 'app-blog-subscription',
   standalone: true,
@@ -29,7 +31,7 @@ export class BlogSubscriptionComponent {
 
     if (payload.website) {
       this.status.set('success');
-      this.statusMessage.set('If that email can be subscribed, a confirmation link is on the way.');
+      this.statusMessage.set(SIGNUP_SUCCESS_MESSAGE);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Adds junk/spam guidance to the blog subscription success message and field help.
- Clarifies the confirmation email was requested from `https://drakesfood.com`.
- Keeps the generic success response so the API still avoids revealing subscription status.

Closes #92.

## Validation
- `node --test infra/lambda/blog-subscriptions/index.test.mjs`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Visual Review
- Not run in browser; copy-only change validated by production build.

## Notes
- Local Node is `v25.9.0`, so Angular warns that it is not an LTS release, but lint and build passed.