### PR TITLE
Improve multi-page accessibility polish

### DIFF
--- a/TODO_STATUS.md
+++ b/TODO_STATUS.md
@@ -53,6 +53,7 @@
 - [x] Add first recipe/story blog detail page
 - [x] Document blog email notification operations — #85
 - [x] Notify Drake when readers subscribe or unsubscribe — #88
+- [x] Complete accessibility and mobile polish pass for multi-page site — #65
 
 ## 🔄 In Progress
 
@@ -141,6 +142,7 @@ Active work is now tracked in GitHub Issues. Pull the next task from the highest
 - Blog email operations documentation is being expanded into a setup, testing, sending, privacy, cost, and recovery runbook.
 - Optional blog subscription admin alerts are being added so Drake can be notified after confirmed subscriptions and unsubscribes without exposing subscriber emails in alert bodies.
 - SES deliverability verification is in progress for #94. Production access, domain verification, and DKIM are confirmed in `us-east-2`; SPF is being added through OpenTofu and the existing DKIM/DMARC records are being brought under infrastructure management.
+- Multi-page accessibility polish added active navigation semantics, route-change focus handling, page-level headings, form invalid-state announcements, invalid-field focus, required-label text for screen readers, clearer external-link labels, and mobile nav tap-target sizing.
 
 ## Last Updated
 

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -7,6 +7,10 @@
   color: var(--color-text);
 }
 
+#main-content:focus {
+  outline: none;
+}
+
 .site-header {
   display: flex;
   flex-direction: column;
@@ -39,6 +43,7 @@
 }
 
 .primary-nav a {
+  min-height: 2.75rem;
   border: 1px solid rgba(109, 74, 163, 0.16);
   border-radius: 999px;
   background: rgba(255, 250, 245, 0.68);

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -12,21 +12,28 @@
       <span>Drake's Food</span>
     </a>
     <nav class="primary-nav" aria-label="Primary navigation">
-      <a routerLink="/" routerLinkActive="active-link" [routerLinkActiveOptions]="{ exact: true }"
+      <a
+        routerLink="/"
+        routerLinkActive="active-link"
+        ariaCurrentWhenActive="page"
+        [routerLinkActiveOptions]="{ exact: true }"
         >Home</a
       >
-      <a routerLink="/gallery" routerLinkActive="active-link">Gallery</a>
-      <a routerLink="/blog" routerLinkActive="active-link">Blog</a>
+      <a routerLink="/gallery" routerLinkActive="active-link" ariaCurrentWhenActive="page"
+        >Gallery</a
+      >
+      <a routerLink="/blog" routerLinkActive="active-link" ariaCurrentWhenActive="page">Blog</a>
       <a
         routerLink="/recipesensei"
         routerLinkActive="active-link"
+        ariaCurrentWhenActive="page"
         [routerLinkActiveOptions]="{ exact: true }"
         >RecipeSensei</a
       >
-      <a routerLink="/about" routerLinkActive="active-link">About</a>
+      <a routerLink="/about" routerLinkActive="active-link" ariaCurrentWhenActive="page">About</a>
     </nav>
   </header>
-  <main id="main-content">
+  <main id="main-content" tabindex="-1">
     <router-outlet></router-outlet>
   </main>
   <app-site-footer></app-site-footer>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -159,7 +159,6 @@ export class App {
 
     window?.requestAnimationFrame(() => {
       mainContent?.focus({ preventScroll: true });
-      window.scrollTo({ top: 0, left: 0 });
     });
   }
 }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -95,7 +95,10 @@ export class App {
         filter((event): event is NavigationEnd => event instanceof NavigationEnd),
         takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe((event) => this.applyPageMetadata(event.urlAfterRedirects));
+      .subscribe((event) => {
+        this.applyPageMetadata(event.urlAfterRedirects);
+        this.focusMainContent();
+      });
   }
 
   private applyPageMetadata(url: string): void {
@@ -148,5 +151,15 @@ export class App {
     }
 
     canonicalLink.href = canonicalUrl;
+  }
+
+  private focusMainContent(): void {
+    const mainContent = this.document.getElementById('main-content');
+    const window = this.document.defaultView;
+
+    window?.requestAnimationFrame(() => {
+      mainContent?.focus({ preventScroll: true });
+      window.scrollTo({ top: 0, left: 0 });
+    });
   }
 }

--- a/src/app/components/blog-subscription/blog-subscription.component.html
+++ b/src/app/components/blog-subscription/blog-subscription.component.html
@@ -3,13 +3,17 @@
     <p class="eyebrow">New post emails</p>
     <h3 id="blog-subscription-title">Get the next kitchen story.</h3>
     <p>
-      I will email you when a new Drake's Food post goes live. No spam, no accounts, and you can unsubscribe anytime.
+      I will email you when a new Drake's Food post goes live. No spam, no accounts, and you can
+      unsubscribe anytime.
     </p>
   </div>
 
   <form class="subscription-form" [formGroup]="subscriptionForm" (ngSubmit)="onSubmit()" novalidate>
     <div class="field">
-      <label for="blog-subscription-email">Email address <span aria-hidden="true">*</span></label>
+      <label for="blog-subscription-email"
+        >Email address <span aria-hidden="true">*</span
+        ><span class="visually-hidden"> required</span></label
+      >
       <input
         id="blog-subscription-email"
         type="email"
@@ -17,9 +21,12 @@
         autocomplete="email"
         maxlength="254"
         placeholder="you@example.com"
-        aria-describedby="blog-subscription-help blog-subscription-error"
+        [attr.aria-describedby]="emailDescribedBy()"
+        [attr.aria-invalid]="emailHasVisibleError() ? 'true' : null"
       />
-      <p id="blog-subscription-help" class="field-help">Confirm your email before updates start arriving. Check junk or spam if the link is slow.</p>
+      <p id="blog-subscription-help" class="field-help">
+        Confirm your email before updates start arriving. Check junk or spam if the link is slow.
+      </p>
       @if (hasFieldError('email', 'required')) {
         <p id="blog-subscription-error" class="field-error">Please enter your email address.</p>
       } @else if (hasFieldError('email', 'email')) {
@@ -31,7 +38,13 @@
 
     <div class="honeypot" aria-hidden="true">
       <label for="blog-subscription-website">Website</label>
-      <input id="blog-subscription-website" type="text" formControlName="website" tabindex="-1" autocomplete="off" />
+      <input
+        id="blog-subscription-website"
+        type="text"
+        formControlName="website"
+        tabindex="-1"
+        autocomplete="off"
+      />
     </div>
 
     <button class="button button-primary" type="submit" [disabled]="isSubmitting()">
@@ -43,7 +56,12 @@
     </button>
 
     @if (statusMessage()) {
-      <p class="status-message" [class.status-success]="status() === 'success'" [class.status-error]="status() === 'error'" aria-live="polite">
+      <p
+        class="status-message"
+        [class.status-success]="status() === 'success'"
+        [class.status-error]="status() === 'error'"
+        aria-live="polite"
+      >
         {{ statusMessage() }}
       </p>
     }

--- a/src/app/components/blog-subscription/blog-subscription.component.ts
+++ b/src/app/components/blog-subscription/blog-subscription.component.ts
@@ -1,10 +1,14 @@
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, ElementRef, computed, inject, signal } from '@angular/core';
 import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { BlogSubscriptionApiService, type BlogSubscriptionPayload } from '../../services/blog-subscription-api.service';
+import {
+  BlogSubscriptionApiService,
+  type BlogSubscriptionPayload,
+} from '../../services/blog-subscription-api.service';
 
 type SubscriptionStatus = 'idle' | 'submitting' | 'success' | 'error';
 
-const SIGNUP_SUCCESS_MESSAGE = 'If that email can be subscribed, a confirmation link is on the way. Check your junk or spam folder if you do not see it soon.';
+const SIGNUP_SUCCESS_MESSAGE =
+  'If that email can be subscribed, a confirmation link is on the way. Check your junk or spam folder if you do not see it soon.';
 
 @Component({
   selector: 'app-blog-subscription',
@@ -16,6 +20,7 @@ const SIGNUP_SUCCESS_MESSAGE = 'If that email can be subscribed, a confirmation 
 export class BlogSubscriptionComponent {
   private readonly formBuilder = inject(NonNullableFormBuilder);
   private readonly blogSubscriptionApi = inject(BlogSubscriptionApiService);
+  private readonly host = inject(ElementRef<HTMLElement>);
 
   readonly status = signal<SubscriptionStatus>('idle');
   readonly statusMessage = signal('');
@@ -39,6 +44,7 @@ export class BlogSubscriptionComponent {
       this.subscriptionForm.markAllAsTouched();
       this.status.set('error');
       this.statusMessage.set('Please enter a valid email address.');
+      this.focusFirstInvalidControl();
       return;
     }
 
@@ -47,7 +53,9 @@ export class BlogSubscriptionComponent {
 
     if (!(await this.blogSubscriptionApi.isConfigured())) {
       this.status.set('error');
-      this.statusMessage.set('Email updates are ready on the site, but the subscription API is not connected yet.');
+      this.statusMessage.set(
+        'Email updates are ready on the site, but the subscription API is not connected yet.',
+      );
       return;
     }
 
@@ -61,7 +69,11 @@ export class BlogSubscriptionComponent {
       this.statusMessage.set(message);
     } catch (error) {
       this.status.set('error');
-      this.statusMessage.set(error instanceof Error ? error.message : 'Blog subscriptions are temporarily unavailable. Please try again later.');
+      this.statusMessage.set(
+        error instanceof Error
+          ? error.message
+          : 'Blog subscriptions are temporarily unavailable. Please try again later.',
+      );
     }
   }
 
@@ -71,6 +83,18 @@ export class BlogSubscriptionComponent {
     return field.hasError(errorName) && (field.dirty || field.touched);
   }
 
+  protected emailHasVisibleError(): boolean {
+    return ['required', 'email', 'maxlength'].some((errorName) =>
+      this.hasFieldError('email', errorName),
+    );
+  }
+
+  protected emailDescribedBy(): string {
+    return this.emailHasVisibleError()
+      ? 'blog-subscription-help blog-subscription-error'
+      : 'blog-subscription-help';
+  }
+
   private buildPayload(): BlogSubscriptionPayload {
     const rawValue = this.subscriptionForm.getRawValue();
 
@@ -78,5 +102,17 @@ export class BlogSubscriptionComponent {
       email: rawValue.email.trim(),
       website: rawValue.website.trim(),
     };
+  }
+
+  private focusFirstInvalidControl(): void {
+    const window = this.host.nativeElement.ownerDocument.defaultView;
+
+    window?.requestAnimationFrame(() => {
+      const firstInvalidControl = this.host.nativeElement.querySelector('[aria-invalid="true"]');
+
+      if (firstInvalidControl instanceof HTMLElement) {
+        firstInvalidControl.focus();
+      }
+    });
   }
 }

--- a/src/app/components/recipe-submission/recipe-submission.component.html
+++ b/src/app/components/recipe-submission/recipe-submission.component.html
@@ -3,19 +3,43 @@
     <p class="eyebrow">Cook this next</p>
     <h2 id="submission-title">Submit a recipe idea.</h2>
     <p>
-      Share a family recipe, cooking challenge, link, or loose idea you would like me to try. Submitted ideas never auto-publish to the site, are reviewed manually, and you may remain anonymous if you wish.
+      Share a family recipe, cooking challenge, link, or loose idea you would like me to try.
+      Submitted ideas never auto-publish to the site, are reviewed manually, and you may remain
+      anonymous if you wish.
     </p>
     <p>
-      Fair warning: you can send a recipe with exact steps, but I am not much of a recipe-rule-follower, per se. I reserve the right to improvise, alter, or make my own interpretation of the dish, then share the notes and results back of course.
+      Fair warning: you can send a recipe with exact steps, but I am not much of a
+      recipe-rule-follower, per se. I reserve the right to improvise, alter, or make my own
+      interpretation of the dish, then share the notes and results back of course.
     </p>
   </div>
 
   <form class="submission-form" [formGroup]="submissionForm" (ngSubmit)="onSubmit()" novalidate>
     <div class="form-grid">
       <div class="field field-wide">
-        <label for="recipe-title">Recipe or idea title <span aria-hidden="true">*</span></label>
-        <input id="recipe-title" type="text" formControlName="title" autocomplete="off" maxlength="120" aria-describedby="recipe-title-help recipe-title-error" />
-        <p id="recipe-title-help" class="field-help">A short name like “Smoked birria tacos” or “Grandma’s zucchini fritters”.</p>
+        <label for="recipe-title"
+          >Recipe or idea title <span aria-hidden="true">*</span
+          ><span class="visually-hidden"> required</span></label
+        >
+        <input
+          id="recipe-title"
+          type="text"
+          formControlName="title"
+          autocomplete="off"
+          maxlength="120"
+          [attr.aria-describedby]="
+            fieldDescribedBy('title', 'recipe-title-help', 'recipe-title-error', [
+              'required',
+              'maxlength',
+            ])
+          "
+          [attr.aria-invalid]="
+            fieldHasVisibleError('title', ['required', 'maxlength']) ? 'true' : null
+          "
+        />
+        <p id="recipe-title-help" class="field-help">
+          A short name like “Smoked birria tacos” or “Grandma’s zucchini fritters”.
+        </p>
         @if (hasFieldError('title', 'required')) {
           <p id="recipe-title-error" class="field-error">Please include a recipe title.</p>
         } @else if (hasFieldError('title', 'maxlength')) {
@@ -24,31 +48,85 @@
       </div>
 
       <div class="field field-wide">
-        <label for="recipe-description">Description / notes <span aria-hidden="true">*</span></label>
-        <textarea id="recipe-description" formControlName="description" rows="6" maxlength="3000" aria-describedby="recipe-description-help recipe-description-error"></textarea>
-        <p id="recipe-description-help" class="field-help">Tell Drake what makes it good, where it came from, or how you would cook it.</p>
+        <label for="recipe-description"
+          >Description / notes <span aria-hidden="true">*</span
+          ><span class="visually-hidden"> required</span></label
+        >
+        <textarea
+          id="recipe-description"
+          formControlName="description"
+          rows="6"
+          maxlength="3000"
+          [attr.aria-describedby]="
+            fieldDescribedBy('description', 'recipe-description-help', 'recipe-description-error', [
+              'required',
+              'maxlength',
+            ])
+          "
+          [attr.aria-invalid]="
+            fieldHasVisibleError('description', ['required', 'maxlength']) ? 'true' : null
+          "
+        ></textarea>
+        <p id="recipe-description-help" class="field-help">
+          Tell Drake what makes it good, where it came from, or how you would cook it.
+        </p>
         @if (hasFieldError('description', 'required')) {
-          <p id="recipe-description-error" class="field-error">Please add a few notes about the idea.</p>
+          <p id="recipe-description-error" class="field-error">
+            Please add a few notes about the idea.
+          </p>
         } @else if (hasFieldError('description', 'maxlength')) {
-          <p id="recipe-description-error" class="field-error">Keep the notes under 3,000 characters.</p>
+          <p id="recipe-description-error" class="field-error">
+            Keep the notes under 3,000 characters.
+          </p>
         }
       </div>
 
       <div class="field">
         <label for="submitter-name">Name or handle</label>
-        <input id="submitter-name" type="text" formControlName="name" autocomplete="name" maxlength="100" aria-describedby="submitter-name-help submitter-name-error" />
-        <p id="submitter-name-help" class="field-help">Optional, if you want Drake to know who sent it.</p>
+        <input
+          id="submitter-name"
+          type="text"
+          formControlName="name"
+          autocomplete="name"
+          maxlength="100"
+          [attr.aria-describedby]="
+            fieldDescribedBy('name', 'submitter-name-help', 'submitter-name-error', ['maxlength'])
+          "
+          [attr.aria-invalid]="fieldHasVisibleError('name', ['maxlength']) ? 'true' : null"
+        />
+        <p id="submitter-name-help" class="field-help">
+          Optional, if you want Drake to know who sent it.
+        </p>
         @if (hasFieldError('name', 'maxlength')) {
-          <p id="submitter-name-error" class="field-error">Keep the name or handle under 100 characters.</p>
+          <p id="submitter-name-error" class="field-error">
+            Keep the name or handle under 100 characters.
+          </p>
         }
       </div>
 
       <div class="field">
         <label for="submitter-email">Email</label>
-        <input id="submitter-email" type="email" formControlName="email" autocomplete="email" maxlength="254" aria-describedby="submitter-email-help submitter-email-error" />
+        <input
+          id="submitter-email"
+          type="email"
+          formControlName="email"
+          autocomplete="email"
+          maxlength="254"
+          [attr.aria-describedby]="
+            fieldDescribedBy('email', 'submitter-email-help', 'submitter-email-error', [
+              'email',
+              'maxlength',
+            ])
+          "
+          [attr.aria-invalid]="
+            fieldHasVisibleError('email', ['email', 'maxlength']) ? 'true' : null
+          "
+        />
         <p id="submitter-email-help" class="field-help">Optional, only for follow-up questions.</p>
         @if (hasFieldError('email', 'email')) {
-          <p id="submitter-email-error" class="field-error">Enter a valid email address or leave this blank.</p>
+          <p id="submitter-email-error" class="field-error">
+            Enter a valid email address or leave this blank.
+          </p>
         } @else if (hasFieldError('email', 'maxlength')) {
           <p id="submitter-email-error" class="field-error">Keep the email under 254 characters.</p>
         }
@@ -56,19 +134,49 @@
 
       <div class="field">
         <label for="recipe-url">Recipe URL</label>
-        <input id="recipe-url" type="url" formControlName="recipeUrl" inputmode="url" autocomplete="url" maxlength="500" placeholder="https://" aria-describedby="recipe-url-help recipe-url-error" />
+        <input
+          id="recipe-url"
+          type="url"
+          formControlName="recipeUrl"
+          inputmode="url"
+          autocomplete="url"
+          maxlength="500"
+          placeholder="https://"
+          [attr.aria-describedby]="
+            fieldDescribedBy('recipeUrl', 'recipe-url-help', 'recipe-url-error', ['maxlength'])
+          "
+          [attr.aria-invalid]="fieldHasVisibleError('recipeUrl', ['maxlength']) ? 'true' : null"
+        />
         <p id="recipe-url-help" class="field-help">Optional link to a recipe, video, or notes.</p>
         @if (hasFieldError('recipeUrl', 'maxlength')) {
-          <p id="recipe-url-error" class="field-error">Keep the recipe link under 500 characters.</p>
+          <p id="recipe-url-error" class="field-error">
+            Keep the recipe link under 500 characters.
+          </p>
         }
       </div>
 
       <div class="field">
         <label for="social-url">Social URL</label>
-        <input id="social-url" type="url" formControlName="socialUrl" inputmode="url" autocomplete="url" maxlength="500" placeholder="https://instagram.com/..." aria-describedby="social-url-help social-url-error" />
-        <p id="social-url-help" class="field-help">Optional link to a post or creator who inspired it.</p>
+        <input
+          id="social-url"
+          type="url"
+          formControlName="socialUrl"
+          inputmode="url"
+          autocomplete="url"
+          maxlength="500"
+          placeholder="https://instagram.com/..."
+          [attr.aria-describedby]="
+            fieldDescribedBy('socialUrl', 'social-url-help', 'social-url-error', ['maxlength'])
+          "
+          [attr.aria-invalid]="fieldHasVisibleError('socialUrl', ['maxlength']) ? 'true' : null"
+        />
+        <p id="social-url-help" class="field-help">
+          Optional link to a post or creator who inspired it.
+        </p>
         @if (hasFieldError('socialUrl', 'maxlength')) {
-          <p id="social-url-error" class="field-error">Keep the social link under 500 characters.</p>
+          <p id="social-url-error" class="field-error">
+            Keep the social link under 500 characters.
+          </p>
         }
       </div>
     </div>
@@ -80,7 +188,13 @@
 
     <div class="honeypot" aria-hidden="true">
       <label for="submission-website">Website</label>
-      <input id="submission-website" type="text" formControlName="website" tabindex="-1" autocomplete="off" />
+      <input
+        id="submission-website"
+        type="text"
+        formControlName="website"
+        tabindex="-1"
+        autocomplete="off"
+      />
     </div>
 
     <div class="form-actions">
@@ -91,11 +205,18 @@
           Submit recipe idea
         }
       </button>
-      <p class="form-note">Submissions are text/link only and reviewed manually before anything is shared.</p>
+      <p class="form-note">
+        Submissions are text/link only and reviewed manually before anything is shared.
+      </p>
     </div>
 
     @if (statusMessage()) {
-      <p class="status-message" [class.status-success]="status() === 'success'" [class.status-error]="status() === 'error'" aria-live="polite">
+      <p
+        class="status-message"
+        [class.status-success]="status() === 'success'"
+        [class.status-error]="status() === 'error'"
+        aria-live="polite"
+      >
         {{ statusMessage() }}
       </p>
     }

--- a/src/app/components/recipe-submission/recipe-submission.component.ts
+++ b/src/app/components/recipe-submission/recipe-submission.component.ts
@@ -1,6 +1,9 @@
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, ElementRef, computed, inject, signal } from '@angular/core';
 import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { RecipeSubmissionApiService, type RecipeSubmissionPayload } from '../../services/recipe-submission-api.service';
+import {
+  RecipeSubmissionApiService,
+  type RecipeSubmissionPayload,
+} from '../../services/recipe-submission-api.service';
 
 type SubmissionStatus = 'idle' | 'submitting' | 'success' | 'error';
 
@@ -14,6 +17,7 @@ type SubmissionStatus = 'idle' | 'submitting' | 'success' | 'error';
 export class RecipeSubmissionComponent {
   private readonly formBuilder = inject(NonNullableFormBuilder);
   private readonly recipeSubmissionApi = inject(RecipeSubmissionApiService);
+  private readonly host = inject(ElementRef<HTMLElement>);
 
   readonly status = signal<SubmissionStatus>('idle');
   readonly statusMessage = signal('');
@@ -44,6 +48,7 @@ export class RecipeSubmissionComponent {
       this.submissionForm.markAllAsTouched();
       this.status.set('error');
       this.statusMessage.set('Please include a recipe title and description.');
+      this.focusFirstInvalidControl();
       return;
     }
 
@@ -74,7 +79,11 @@ export class RecipeSubmissionComponent {
       this.statusMessage.set(message);
     } catch (error) {
       this.status.set('error');
-      this.statusMessage.set(error instanceof Error ? error.message : 'Recipe submissions are temporarily unavailable. Please try again later.');
+      this.statusMessage.set(
+        error instanceof Error
+          ? error.message
+          : 'Recipe submissions are temporarily unavailable. Please try again later.',
+      );
     }
   }
 
@@ -82,6 +91,22 @@ export class RecipeSubmissionComponent {
     const field = this.submissionForm.controls[fieldName];
 
     return field.hasError(errorName) && (field.dirty || field.touched);
+  }
+
+  protected fieldHasVisibleError(
+    fieldName: keyof RecipeSubmissionPayload,
+    errorNames: string[],
+  ): boolean {
+    return errorNames.some((errorName) => this.hasFieldError(fieldName, errorName));
+  }
+
+  protected fieldDescribedBy(
+    fieldName: keyof RecipeSubmissionPayload,
+    helpId: string,
+    errorId: string,
+    errorNames: string[],
+  ): string {
+    return this.fieldHasVisibleError(fieldName, errorNames) ? `${helpId} ${errorId}` : helpId;
   }
 
   private buildPayload(): RecipeSubmissionPayload {
@@ -97,5 +122,17 @@ export class RecipeSubmissionComponent {
       permissionToCredit: rawValue.permissionToCredit,
       website: rawValue.website.trim(),
     };
+  }
+
+  private focusFirstInvalidControl(): void {
+    const window = this.host.nativeElement.ownerDocument.defaultView;
+
+    window?.requestAnimationFrame(() => {
+      const firstInvalidControl = this.host.nativeElement.querySelector('[aria-invalid="true"]');
+
+      if (firstInvalidControl instanceof HTMLElement) {
+        firstInvalidControl.focus();
+      }
+    });
   }
 }

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -1,1 +1,2 @@
+<h1 class="visually-hidden">About Drake's Food</h1>
 <app-about></app-about>

--- a/src/app/pages/blog-post-page/blog-post-page.component.html
+++ b/src/app/pages/blog-post-page/blog-post-page.component.html
@@ -43,6 +43,7 @@
             [href]="post.sourceRecipe.href"
             target="_blank"
             rel="noopener"
+            [attr.aria-label]="post.sourceRecipe.label + ', opens in a new tab'"
             >{{ post.sourceRecipe.label }}</a
           >
         </div>

--- a/src/app/pages/recipes-page/recipes-page.component.html
+++ b/src/app/pages/recipes-page/recipes-page.component.html
@@ -1,1 +1,2 @@
+<h1 class="visually-hidden">Drake's Food Blog</h1>
 <app-recipe-blog></app-recipe-blog>

--- a/src/app/pages/recipesensei-page/recipesensei-page.component.html
+++ b/src/app/pages/recipesensei-page/recipesensei-page.component.html
@@ -1,1 +1,2 @@
+<h1 class="visually-hidden">RecipeSensei</h1>
 <app-recipe-sensei></app-recipe-sensei>

--- a/src/app/pages/submit-page/submit-page.component.html
+++ b/src/app/pages/submit-page/submit-page.component.html
@@ -1,1 +1,2 @@
+<h1 class="visually-hidden">Submit a recipe idea</h1>
 <app-recipe-submission></app-recipe-submission>

--- a/src/styles.css
+++ b/src/styles.css
@@ -43,6 +43,18 @@ a {
   color: inherit;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .skip-link {
   position: fixed;
   left: 1rem;


### PR DESCRIPTION
## Summary
- Adds active navigation semantics, route-change focus handling, and page-level headings for component-backed routes.
- Improves form accessibility with required-label text, conditional descriptions, invalid-state announcements, and invalid-field focus.
- Tightens mobile nav tap targets and external-link labeling for assistive tech.

Closes #65

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- Lighthouse accessibility route checks: `/`, `/gallery`, `/blog`, `/blog/mothers-day-baking`, `/submit`, `/recipesensei`, `/recipesensei/support`, `/recipesensei/privacy`, `/about` all scored 100.

## Visual Review
- Automated Lighthouse checks were run against the built static site for the affected routes.
- Manual browser viewport review was not completed in this terminal session.

## Notes
- Validation commands emitted the existing Node `v25.9.0` odd-version warning, but completed successfully.