### PR TITLE
[codex] Add AI agent context guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,7 @@ The site is being fully redesigned as a clean, mobile-first food portfolio and l
 ## Priorities
 
 - Follow `WORKFLOW.md` for branch, pull request, merge, and task-tracking expectations.
+- Use `docs/ai-agent-context.md` for the current code map, common change paths, and validation matrix.
 - Do not merge pull requests. Drake manually reviews and merges PRs.
 - Keep the site simple, fast, accessible, and easy to maintain.
 - Use modern Angular, not legacy AngularJS / Angular 1.x.
@@ -37,18 +38,20 @@ The site should feel:
 
 Avoid cluttered recipe-blog patterns, heavy animations, and unnecessary JavaScript.
 
-## Initial Content Scope
+## Current Content Scope
 
-The first version should include:
+The site currently includes:
 
 - Homepage
 - Food photo gallery
 - Instagram call-to-action
 - About / personal intro section
-- RecipeSensei teaser section
-- Recipe/blog section marked as "coming soon"
+- RecipeSensei section and app links
+- Recipe/blog landing page and a first story page
+- Recipe idea submission form
+- Blog email subscription form
 
-Do not build full recipe/blog functionality yet.
+Do not build a full CMS, user accounts, comments, payments, or complex recipe database unless Drake explicitly requests it.
 
 ## Content Storage
 
@@ -67,7 +70,8 @@ Instagram should be referenced as:
 
 RecipeSensei is Drake's app.
 
-Until Drake confirms launch status, describe it as coming soon or in development. Do not imply it is publicly available unless the content says so.
+Current repository docs indicate RecipeSensei is live on the App Store. Do not invent launch
+details, feature claims, pricing, or availability beyond confirmed project content.
 
 ## AWS / Deployment
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,13 @@ The site is being fully redesigned as a clean, modern, mobile-first food portfol
 
 The website should feel personal, polished, warm, food-focused, and lightweight. It is not currently intended to be a complex social platform, recipe database, or user-account system.
 
+## AI Quick Context
+
+- Read `WORKFLOW.md` for branch, issue, PR, merge, and task-tracking rules.
+- Use `docs/ai-agent-context.md` as the fast project map before making changes.
+- Treat `README.md`, `TODO_STATUS.md`, `docs/`, and `infra/README.md` as the current implementation context.
+- Treat `initial-angular-rebuild-prompt.txt` as historical background, not the current source of truth.
+
 ## Primary Goals
 
 - Showcase high-quality food photos in a visually appealing way.
@@ -45,28 +52,27 @@ Recommended first version:
 - Use S3 later if the gallery grows or if image management becomes annoying.
 - Link prominently to Instagram `@drakesfood`.
 
-### Initial Content Scope
+### Current Content Scope
 
-The first version should focus on:
+The current site includes:
 
 - Homepage
 - Food photo gallery
 - Instagram call-to-action
 - About / personal intro section
-- RecipeSensei teaser section
-- Recipe/blog section marked as "coming soon"
+- RecipeSensei section and app links
+- Recipe/blog landing page
+- First blog story page
+- Recipe idea submission form
+- Blog email subscription form
 
-Do not build full recipe/blog functionality yet.
+Do not build a full CMS, user account system, comments, or complex recipe database unless Drake explicitly requests it.
 
 ### RecipeSensei
 
-For now, include a simple RecipeSensei teaser section.
-
-RecipeSensei should be described as in development or coming soon until Drake confirms it is publicly available.
-
-Possible copy direction:
-
-> RecipeSensei is a recipe-saving and cooking companion app currently in development. More coming soon.
+RecipeSensei is Drake's recipe-saving and cooking companion app. Current repository docs
+indicate it is live on the App Store, so copy may link to the app. Do not invent launch
+details, feature claims, pricing, or availability beyond confirmed project content.
 
 ### Infrastructure Location
 
@@ -114,14 +120,16 @@ Do not add deployment steps that require paid third-party services unless Drake 
 
 ## Product Direction
 
-The site should eventually include:
+The site currently includes or is expected to continue supporting:
 
 - Homepage / landing page
 - Food photo gallery
 - Instagram call-to-action
 - About section
-- RecipeSensei teaser or app link section
-- Optional featured recipes or cooking posts in the future
+- RecipeSensei app link section
+- Lightweight recipe/blog posts
+- Recipe idea submissions
+- Blog email subscriptions
 
 Do not build advanced functionality unless requested. Avoid adding accounts, comments, payments, CMS complexity, databases, or server-side features unless they are explicitly approved.
 
@@ -259,13 +267,7 @@ Prioritize fast load times.
 
 The site should speak in Drake's voice: friendly, casual, and food-loving.
 
-Avoid fake claims, fake restaurant affiliations, or fake app availability.
-
-RecipeSensei should only be described as available once Drake confirms it is ready. Until then, phrase it as:
-
-- "Coming soon"
-- "In development"
-- "A future app for saving and organizing recipes"
+Avoid fake claims, fake restaurant affiliations, or fake app details.
 
 Instagram should be referenced as:
 
@@ -329,15 +331,14 @@ Before making broad changes:
 - Explain major architectural changes before implementing them.
 - Update documentation when changing setup, deployment, or commands.
 
-For large redesign work, prefer phases:
+For large redesign or expansion work, prefer phases:
 
-1. Establish project structure.
-2. Add design system and layout shell.
-3. Build homepage.
-4. Build gallery/content sections.
-5. Add RecipeSensei section.
-6. Add AWS/OpenTofu deployment.
-7. Add CI/CD validation.
+1. Confirm the current route/content map.
+2. Establish or refine the layout shell.
+3. Update the target page or feature.
+4. Update metadata, sitemap, and generated route HTML if public routes change.
+5. Update docs for setup, content, infrastructure, or operations changes.
+6. Run focused validation.
 
 ## Agent Behavior
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Drake's Food
 
-A modern Angular portfolio website for Drake's Food. This first version is a warm, minimal, photo-forward multi-page site with a food gallery preview, Instagram CTA, about section, RecipeSensei links, recipe idea submission, and a recipe/blog coming soon area.
+A modern Angular portfolio website for Drake's Food. The current site is a warm, minimal,
+photo-forward multi-page Angular app with a food gallery, Instagram CTA, about section,
+RecipeSensei links, recipe idea submission, blog story content, and blog email subscriptions.
 
 ## Getting started
 
@@ -52,6 +54,7 @@ npm run lint
 - `src/app/data/` - static gallery data and content models
 - `src/assets/images/` - local optimized food photography and site image assets
 - `docs/` - feature contracts and implementation notes
+- `docs/ai-agent-context.md` - fast project map and validation guide for AI assistants
 - `infra/` - OpenTofu infrastructure for S3, CloudFront, ACM, and Route 53
 - `.github/copilot-instructions.md` - project guidance for Copilot
 - `public/` - static assets for app build
@@ -64,7 +67,7 @@ The site uses Angular routes for the primary content areas while staying static-
 - `/gallery` - food gallery page
 - `/blog` - Drake's Food blog stories and recipe notes
 - `/submit` - recipe idea submission page
-- `/recipesensei` - RecipeSensei app teaser and links
+- `/recipesensei` - RecipeSensei app links and overview
 - `/about` - Drake's Food intro page
 - `/recipesensei/support` - RecipeSensei support page
 - `/recipesensei/privacy` - RecipeSensei privacy policy page
@@ -98,7 +101,9 @@ The V1 recipe submission system is documented in `docs/recipe-submission-system.
 
 ## Blog email subscriptions
 
-The V1 blog email subscription signup and confirmation system is documented in `docs/blog-email-subscriptions.md`. It uses confirmed opt-in before activating subscribers. Unsubscribe support and new-post notification sending are tracked separately.
+The V1 blog email subscription signup, confirmation, unsubscribe, admin alert, and manual
+new-post notification system is documented in `docs/blog-email-subscriptions.md`. It uses
+confirmed opt-in before activating subscribers.
 
 ## Deployment
 
@@ -114,4 +119,5 @@ CloudFront redirects plain HTTP requests to HTTPS and maps S3 `403`/`404` respon
 
 ## Notes
 
-The site is intentionally mostly static. It is designed for AWS S3 + CloudFront and does not include authentication, backend services, or CMS tools.
+The site is intentionally mostly static. It is designed for AWS S3 + CloudFront and avoids
+authentication, CMS tooling, and unnecessary backend complexity.

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -7,6 +7,7 @@ The site is being fully redesigned as a clean, mobile-first food portfolio and l
 ## Priorities
 
 - Follow `WORKFLOW.md` for branch, pull request, merge, and task-tracking expectations.
+- Use `docs/ai-agent-context.md` for the current code map, common change paths, and validation matrix.
 - Do not merge pull requests. Drake manually reviews and merges PRs.
 - Keep the site simple, fast, accessible, and easy to maintain.
 - Use modern Angular, not legacy AngularJS / Angular 1.x.
@@ -37,18 +38,20 @@ The site should feel:
 
 Avoid cluttered recipe-blog patterns, heavy animations, and unnecessary JavaScript.
 
-## Initial Content Scope
+## Current Content Scope
 
-The first version should include:
+The site currently includes:
 
 - Homepage
 - Food photo gallery
 - Instagram call-to-action
 - About / personal intro section
-- RecipeSensei teaser section
-- Recipe/blog section marked as "coming soon"
+- RecipeSensei section and app links
+- Recipe/blog landing page and a first story page
+- Recipe idea submission form
+- Blog email subscription form
 
-Do not build full recipe/blog functionality yet.
+Do not build a full CMS, user accounts, comments, payments, or complex recipe database unless Drake explicitly requests it.
 
 ## Content Storage
 
@@ -67,7 +70,8 @@ Instagram should be referenced as:
 
 RecipeSensei is Drake's app.
 
-Until Drake confirms launch status, describe it as coming soon or in development. Do not imply it is publicly available unless the content says so.
+Current repository docs indicate RecipeSensei is live on the App Store. Do not invent launch
+details, feature claims, pricing, or availability beyond confirmed project content.
 
 ## AWS / Deployment
 

--- a/docs/ai-agent-context.md
+++ b/docs/ai-agent-context.md
@@ -1,0 +1,99 @@
+# AI Agent Context
+
+This is the fast handoff file for AI assistants working on Drake's Food. Read `AGENTS.md`
+and `WORKFLOW.md` first, then use this file to find the right code and checks quickly.
+
+## Current Shape
+
+- Modern Angular app with standalone components and static-first routes.
+- Public site routes live in `src/app/app.routes.ts`.
+- Runtime page metadata lives in `src/app/app.ts`.
+- Static route HTML metadata generation lives in `scripts/generate-route-html.mjs`.
+- Gallery content lives in `src/app/data/gallery.data.ts`.
+- Blog post content lives in `src/app/data/blog-posts.data.ts`.
+- Public static assets live in `public/`.
+- Angular-managed image assets live in `src/assets/images/`.
+- AWS/OpenTofu infrastructure lives in `infra/`.
+- Lambda handlers and tests live under `infra/lambda/`.
+
+## High-Value Local Docs
+
+- `README.md` - setup, route map, content and deployment overview.
+- `TODO_STATUS.md` - high-level status snapshot; GitHub Issues remain the active backlog.
+- `docs/recipe-submission-system.md` - recipe submission frontend, API, infra, and testing notes.
+- `docs/recipe-submission-api.md` - recipe submission API contract.
+- `docs/blog-email-subscriptions.md` - blog email subscription, unsubscribe, and notification operations.
+- `infra/README.md` - OpenTofu setup, state guidance, AWS outputs, and GitHub Actions variables.
+- `session-ses_234e-next-steps.md` - temporary SES follow-up notes; verify freshness before using.
+- `initial-angular-rebuild-prompt.txt` - historical rebuild prompt, not current source of truth.
+
+## Common Change Paths
+
+When adding or changing a public route:
+
+- Update `src/app/app.routes.ts`.
+- Add or update metadata in `src/app/app.ts`.
+- Add matching static metadata in `scripts/generate-route-html.mjs`.
+- Add the canonical URL to `public/sitemap.xml` if the page should be indexed.
+- Preserve redirects when renaming public URLs.
+
+When adding gallery photos:
+
+- Put optimized source images in `src/assets/images/`.
+- Put card-sized variants in `src/assets/images/gallery-cards/`.
+- Add entries to `src/app/data/gallery.data.ts` with specific `altText`.
+- Keep non-hero images lazy-loaded and reserve high fetch priority for the main hero only.
+
+When adding blog content:
+
+- Add the post data to `src/app/data/blog-posts.data.ts`.
+- Put post assets under `public/assets/blog/<post-slug>/`.
+- Add route metadata for `/blog/<post-slug>` in both metadata locations.
+- Add a sitemap entry if the post should be indexed.
+- If notifying subscribers, use the manual GitHub Actions workflow after dry-run review.
+
+When changing forms or runtime API config:
+
+- Recipe submissions use `RecipeSubmissionApiService` and `public/app-config.json`.
+- Blog subscriptions use `BlogSubscriptionApiService` and `public/app-config.json`.
+- Keep the not-configured fallback behavior intact for missing API base URLs.
+- Check the matching docs under `docs/` and the Lambda implementation under `infra/lambda/`.
+
+When changing infrastructure:
+
+- Read `infra/README.md` first.
+- Do not commit `.tfvars`, state, plans, credentials, account IDs, or private certificates.
+- Prefer documenting required values over inventing them.
+- Ask before changes that affect AWS cost, DNS, certificates, state backend, or production behavior.
+
+## Validation Matrix
+
+- Content-only docs change: no build required unless code examples or commands changed.
+- Angular content/component/style change: run `npm run lint`, `npm run typecheck`, and `npm run build`.
+- UI/layout/accessibility change: also run the app locally and review desktop and mobile viewports.
+- Route or SEO metadata change: run `npm run build` and inspect generated route HTML as needed.
+- Lambda change: run the relevant `node --test infra/lambda/.../*.test.mjs` test, then run app checks if frontend wiring changed.
+- OpenTofu change: run formatting/validation/plan only with the correct AWS profile and never commit generated state.
+
+Only claim a check passed if it was actually run.
+
+## Existing AI Surfaces
+
+- `AGENTS.md` is the broad agent policy and product direction.
+- `.github/copilot-instructions.md` is the primary GitHub Copilot instruction file.
+- `copilot-instructions.md` is a root copy kept for tools that look outside `.github/`.
+- `.vscode/mcp.json` enables the Angular CLI MCP server for tools that support MCP.
+
+For Codex work in this repo, the most useful built-in capabilities are:
+
+- Browser or frontend testing/debugging tools for visual QA after UI changes.
+- OpenAI/browser search only when checking current external facts or docs.
+- GitHub tools when a task explicitly needs issue, PR, or CI context.
+
+## Watchouts
+
+- The app has grown beyond the original simple landing page. Avoid relying only on early rebuild notes.
+- RecipeSensei is now represented in repo docs as live on the App Store; do not revert copy to "coming soon" unless Drake asks.
+- Metadata is duplicated intentionally between Angular runtime code and generated static route HTML.
+- `public/app-config.json` contains local/default runtime config only; deploy writes production values from GitHub repository variables.
+- Local OpenTofu state and `.tfvars` may exist in a working tree but are ignored and should not be read into commits.


### PR DESCRIPTION
## Summary

- Add `docs/ai-agent-context.md` as a fast handoff map for AI assistants working in this repo.
- Point AGENTS and Copilot instruction files at the new context guide.
- Refresh stale project guidance so it matches the current routed/blog/subscription/RecipeSensei state.
- Update README project structure and current feature wording.

## Why

The repository already had good guidance, but the context was spread across several files and some instructions still described earlier project assumptions. This gives future Codex, Copilot, and other AI-assisted runs a sharper starting point and clearer validation paths.

## Validation

- `git diff --check`

No Angular build was run because this is documentation-only.

## Notes

No linked issue for this housekeeping pass.