### PR TITLE
[codex] Fix one-click unsubscribe redirects

### DIFF
--- a/docs/blog-email-subscriptions.md
+++ b/docs/blog-email-subscriptions.md
@@ -105,7 +105,9 @@ Unsubscribe mutation endpoint:
 POST /blog-subscriptions/unsubscribe?token=<unsubscribe-token>
 ```
 
-Valid unsubscribe tokens mark the subscriber as `unsubscribed` and redirect to `/blog?subscription=unsubscribed`. Repeated unsubscribe requests are treated as success. Invalid tokens redirect to `/blog?subscription=invalid`.
+Browser form POSTs from the confirmation page mark the subscriber as `unsubscribed` and redirect to `/blog?subscription=unsubscribed`. Repeated unsubscribe requests are treated as success. Invalid browser form tokens redirect to `/blog?subscription=invalid`.
+
+Mailbox provider one-click unsubscribe POSTs use the same endpoint with a form body of `List-Unsubscribe=One-Click`. Valid or already-unsubscribed one-click requests return a direct `200` success response without an HTTPS redirect. Missing or invalid one-click tokens return non-redirect error responses.
 
 ## Backend Resources
 
@@ -191,7 +193,7 @@ Notification emails are sent only to subscribers with `status: active` and an `u
 
 Blog notification emails use a multipart plain-text + lightweight HTML format. The plain-text part keeps a readable fallback, and the HTML part may include the post hero image when `blog-notification-posts.mjs` provides `heroImagePath` and `heroImageAlt`. Missing image metadata should not block a send.
 
-Notification emails also include `List-Unsubscribe` and `List-Unsubscribe-Post` headers. The visible unsubscribe link lands on the confirmation page, while mailbox provider one-click unsubscribe requests may use the POST flow directly.
+Notification emails also include `List-Unsubscribe` and `List-Unsubscribe-Post` headers. The visible unsubscribe link lands on the confirmation page, while mailbox provider one-click unsubscribe requests POST `List-Unsubscribe=One-Click` to the unsubscribe URL and receive non-redirect responses.
 
 ## Admin Alerts
 
@@ -220,6 +222,7 @@ Subscriber email addresses are private data.
 - Confirmation tokens are stored only as SHA-256 hashes.
 - Unsubscribe tokens are private bearer-token data. Store them only in DynamoDB, use them only for notification email links, and do not log them.
 - Every future notification email must include the subscriber's unsubscribe link. That link should use `GET /blog-subscriptions/unsubscribe?token=<unsubscribe-token>` so the reader lands on the confirmation page before any state change.
+- One-click unsubscribe support is limited to mailbox provider POSTs containing `List-Unsubscribe=One-Click`; these requests must not redirect.
 
 ## SES
 

--- a/infra/lambda/blog-subscriptions/index.mjs
+++ b/infra/lambda/blog-subscriptions/index.mjs
@@ -239,8 +239,16 @@ async function renderUnsubscribeConfirmation(event, { findSubscriberByUnsubscrib
 async function unsubscribeFromBlog(event, { now, findSubscriberByUnsubscribeTokenHash, unsubscribeSubscriber, sendAdminNotification }) {
   const token = getQueryStringParameter(event, 'token');
   const siteUrl = getSiteUrl();
+  const oneClick = isOneClickUnsubscribePost(event);
 
   if (!token) {
+    if (oneClick) {
+      return jsonResponse(400, {
+        success: false,
+        message: 'Missing unsubscribe token.',
+      });
+    }
+
     return redirectResponse(`${siteUrl}${CONFIRMATION_FAILURE_REDIRECT}`);
   }
 
@@ -248,10 +256,24 @@ async function unsubscribeFromBlog(event, { now, findSubscriberByUnsubscribeToke
   const subscriber = await findSubscriberByUnsubscribeTokenHash(unsubscribeTokenHash);
 
   if (!subscriber) {
+    if (oneClick) {
+      return jsonResponse(404, {
+        success: false,
+        message: 'Unsubscribe token was not found.',
+      });
+    }
+
     return redirectResponse(`${siteUrl}${CONFIRMATION_FAILURE_REDIRECT}`);
   }
 
   if (subscriber.status === 'unsubscribed') {
+    if (oneClick) {
+      return jsonResponse(200, {
+        success: true,
+        message: 'You are unsubscribed.',
+      });
+    }
+
     return redirectResponse(`${siteUrl}${UNSUBSCRIBE_SUCCESS_REDIRECT}`);
   }
 
@@ -265,7 +287,21 @@ async function unsubscribeFromBlog(event, { now, findSubscriberByUnsubscribeToke
       subscriberId: subscriber.subscriberId,
     });
 
+    if (oneClick) {
+      return jsonResponse(500, {
+        success: false,
+        message: 'Unsubscribe is temporarily unavailable. Please try again later.',
+      });
+    }
+
     return redirectResponse(`${siteUrl}${CONFIRMATION_FAILURE_REDIRECT}`);
+  }
+
+  if (oneClick) {
+    return jsonResponse(200, {
+      success: true,
+      message: 'You are unsubscribed.',
+    });
   }
 
   return redirectResponse(`${siteUrl}${UNSUBSCRIBE_SUCCESS_REDIRECT}`);
@@ -449,6 +485,18 @@ function parseBody(event, maxBodyBytes) {
   }
 
   return parsed;
+}
+
+function isOneClickUnsubscribePost(event) {
+  const rawBody = event.isBase64Encoded ? Buffer.from(event.body ?? '', 'base64').toString('utf8') : event.body;
+
+  if (!rawBody) {
+    return false;
+  }
+
+  const params = new URLSearchParams(rawBody);
+
+  return params.get('List-Unsubscribe') === 'One-Click';
 }
 
 function isAllowedOrigin(event) {

--- a/infra/lambda/blog-subscriptions/index.test.mjs
+++ b/infra/lambda/blog-subscriptions/index.test.mjs
@@ -34,7 +34,7 @@ function createConfirmEvent(token) {
   };
 }
 
-function createUnsubscribeEvent(token, method = 'GET') {
+function createUnsubscribeEvent(token, method = 'GET', body) {
   return {
     requestContext: {
       http: {
@@ -45,6 +45,7 @@ function createUnsubscribeEvent(token, method = 'GET') {
     queryStringParameters: {
       token,
     },
+    body,
   };
 }
 
@@ -456,6 +457,33 @@ test('valid unsubscribe token marks subscriber unsubscribed and redirects to suc
   delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
 });
 
+test('valid one-click unsubscribe token marks subscriber unsubscribed without redirecting', async () => {
+  const unsubscribes = [];
+  const emailHash = hash('fan@example.com');
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    now: () => fixedDate,
+    findSubscriberByUnsubscribeTokenHash: async (unsubscribeTokenHash) => ({
+      subscriberId: 'subscriber-123',
+      emailHash,
+      unsubscribeTokenHash,
+      status: 'active',
+    }),
+    unsubscribeSubscriber: async (unsubscribedEmailHash, unsubscribedAt) => unsubscribes.push({ emailHash: unsubscribedEmailHash, unsubscribedAt }),
+  });
+
+  const response = await handler(createUnsubscribeEvent('unsubscribe-token', 'POST', 'List-Unsubscribe=One-Click'));
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers.location, undefined);
+  assert.deepEqual(parseResponse(response), {
+    success: true,
+    message: 'You are unsubscribed.',
+  });
+  assert.deepEqual(unsubscribes, [{ emailHash, unsubscribedAt: '2026-05-09T12:00:00.000Z' }]);
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
 test('valid unsubscribe sends admin notification when configured', async () => {
   const adminNotifications = [];
   const emailHash = hash('fan@example.com');
@@ -542,6 +570,33 @@ test('already unsubscribed token redirects to success without another update', a
   delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
 });
 
+test('already unsubscribed one-click token succeeds without another update', async () => {
+  const unsubscribes = [];
+  const adminNotifications = [];
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    findSubscriberByUnsubscribeTokenHash: async () => ({
+      subscriberId: 'subscriber-123',
+      emailHash: hash('fan@example.com'),
+      status: 'unsubscribed',
+    }),
+    unsubscribeSubscriber: async (emailHash) => unsubscribes.push(emailHash),
+    sendAdminNotification: async (eventType) => adminNotifications.push(eventType),
+  });
+
+  const response = await handler(createUnsubscribeEvent('unsubscribe-token', 'POST', 'List-Unsubscribe=One-Click'));
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers.location, undefined);
+  assert.deepEqual(parseResponse(response), {
+    success: true,
+    message: 'You are unsubscribed.',
+  });
+  assert.deepEqual(unsubscribes, []);
+  assert.deepEqual(adminNotifications, []);
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
 test('invalid unsubscribe token redirects to failure', async () => {
   process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
   const handler = createHandler({
@@ -552,6 +607,38 @@ test('invalid unsubscribe token redirects to failure', async () => {
 
   assert.equal(response.statusCode, 302);
   assert.equal(response.headers.location, 'https://drakesfood.com/blog?subscription=invalid');
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
+test('invalid one-click unsubscribe token returns non-redirect failure', async () => {
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler({
+    findSubscriberByUnsubscribeTokenHash: async () => undefined,
+  });
+
+  const response = await handler(createUnsubscribeEvent('bad-token', 'POST', 'List-Unsubscribe=One-Click'));
+
+  assert.equal(response.statusCode, 404);
+  assert.equal(response.headers.location, undefined);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Unsubscribe token was not found.',
+  });
+  delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
+});
+
+test('missing one-click unsubscribe token returns non-redirect failure', async () => {
+  process.env.BLOG_SUBSCRIPTIONS_SITE_URL = 'https://drakesfood.com';
+  const handler = createHandler();
+
+  const response = await handler(createUnsubscribeEvent(undefined, 'POST', 'List-Unsubscribe=One-Click'));
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.headers.location, undefined);
+  assert.deepEqual(parseResponse(response), {
+    success: false,
+    message: 'Missing unsubscribe token.',
+  });
   delete process.env.BLOG_SUBSCRIPTIONS_SITE_URL;
 });
 


### PR DESCRIPTION
## Summary
- Return direct non-redirect JSON responses for RFC 8058 one-click unsubscribe POSTs.
- Keep the browser confirmation-page POST redirect behavior unchanged.
- Document the split browser/provider unsubscribe contract.

## Root cause
Notification emails advertise `List-Unsubscribe-Post: List-Unsubscribe=One-Click`, but the shared unsubscribe POST handler previously always returned a `302` redirect after updating the subscriber. Mailbox provider one-click checks expect the advertised POST flow to avoid HTTPS redirects.

## Validation
- `node --test infra/lambda/blog-subscriptions/index.test.mjs`
- `npm run lint`

Closes #108