### PR TITLE
Add CloudFront security response headers

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -8,6 +8,7 @@ OpenTofu manages the AWS resources needed to serve `drakesfood.com` over HTTPS.
 - Private bucket access restricted to CloudFront
 - ACM certificate for `drakesfood.com` and `www.drakesfood.com`
 - CloudFront distribution with HTTP-to-HTTPS redirects
+- CloudFront response headers policy for browser security headers
 - Route 53 alias records for apex and `www`
 - IAM user policy for GitHub Actions deployment
 - API Gateway HTTP API for recipe submissions
@@ -203,4 +204,4 @@ After DNS propagation, these URLs should work:
 
 The canonical URL is `https://drakesfood.com/`. The `www` hostname intentionally serves the same site through the same CloudFront distribution for compatibility; canonical metadata and sitemap URLs should continue to use the apex domain.
 
-Plain HTTP requests should redirect to HTTPS. Direct refreshes for Angular routes should return the app with a `200` response because CloudFront maps S3 `403` and `404` responses to `/index.html`.
+Plain HTTP requests should redirect to HTTPS. CloudFront should include the configured security response headers on viewer responses, including HSTS, CSP, content type sniffing protection, referrer policy, and frame protection. Direct refreshes for Angular routes should return the app with a `200` response because CloudFront maps S3 `403` and `404` responses to `/index.html`.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -68,6 +68,39 @@ resource "aws_cloudfront_origin_access_control" "site" {
   signing_protocol                  = "sigv4"
 }
 
+resource "aws_cloudfront_response_headers_policy" "site_security" {
+  name    = "${replace(var.domain_name, ".", "-")}-security-headers"
+  comment = "Security headers for ${var.domain_name}"
+
+  security_headers_config {
+    content_security_policy {
+      content_security_policy = "default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https:; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+      override                = true
+    }
+
+    content_type_options {
+      override = true
+    }
+
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+
+    referrer_policy {
+      referrer_policy = "strict-origin-when-cross-origin"
+      override        = true
+    }
+
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      preload                    = true
+      override                   = true
+    }
+  }
+}
+
 resource "aws_cloudfront_distribution" "site" {
   enabled             = true
   is_ipv6_enabled     = true
@@ -83,11 +116,12 @@ resource "aws_cloudfront_distribution" "site" {
   }
 
   default_cache_behavior {
-    target_origin_id       = "s3-${aws_s3_bucket.site.id}"
-    viewer_protocol_policy = "redirect-to-https"
-    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
-    cached_methods         = ["GET", "HEAD"]
-    compress               = true
+    target_origin_id           = "s3-${aws_s3_bucket.site.id}"
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    compress                   = true
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.site_security.id
 
     forwarded_values {
       query_string = false


### PR DESCRIPTION
## Summary
- Add a CloudFront response headers policy for the static site distribution.
- Attach the policy to the default cache behavior.
- Document the managed security headers in the infrastructure README.

Closes #100

## Security headers
- `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`
- `Content-Security-Policy` in enforce mode
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `X-Frame-Options: DENY`

## Validation
- `tofu fmt -check infra` passed
- `tofu validate` passed
- `git diff --check` passed

## Notes
- `AWS_PROFILE=drakesfood tofu plan` could not complete locally because the cached AWS SSO token is expired (`InvalidGrantException`). Re-run after `aws sso login --profile drakesfood` before applying.
- No frontend files changed, so no local visual review was needed.