### PR TITLE
Add tiny frying pan food-catch game

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -11,6 +11,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://drakesfood.com/game</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://drakesfood.com/blog</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>

--- a/scripts/generate-route-html.mjs
+++ b/scripts/generate-route-html.mjs
@@ -21,6 +21,12 @@ const pageMetadata = {
       "Browse Drake's Food photos, including smoked meats, backyard pizza, family meals, and home-cooking experiments.",
     canonicalPath: '/gallery',
   },
+  '/game': {
+    title: "Frying Pan Food Catch Game | Drake's Food",
+    description:
+      "Play a tiny Drake's Food browser game: move the frying pan, catch the good food, and dodge the rotten stuff.",
+    canonicalPath: '/game',
+  },
   '/blog': {
     title: "Drake's Food Blog | Drake's Food",
     description:

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -15,7 +15,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  width: min(1120px, calc(100% - 2rem));
+  width: min(1120px, calc(100vw - 2rem));
   margin: 0 auto;
   padding: 1rem 0 0.5rem;
 }
@@ -43,6 +43,7 @@
 }
 
 .primary-nav a {
+  flex: 0 0 auto;
   min-height: 2.75rem;
   border: 1px solid rgba(109, 74, 163, 0.16);
   border-radius: 999px;
@@ -52,6 +53,7 @@
   font-size: 0.95rem;
   font-weight: 700;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .primary-nav a:hover,
@@ -84,7 +86,7 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
-    width: min(1120px, calc(100% - 4rem));
+    width: min(1120px, calc(100vw - 4rem));
     padding-top: 1.25rem;
   }
 

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -15,7 +15,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  width: min(1120px, calc(100vw - 2rem));
+  width: min(1120px, calc(100% - 2rem));
   margin: 0 auto;
   padding: 1rem 0 0.5rem;
 }
@@ -86,7 +86,7 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
-    width: min(1120px, calc(100vw - 4rem));
+    width: min(1120px, calc(100% - 4rem));
     padding-top: 1.25rem;
   }
 

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -22,6 +22,7 @@
       <a routerLink="/gallery" routerLinkActive="active-link" ariaCurrentWhenActive="page"
         >Gallery</a
       >
+      <a routerLink="/game" routerLinkActive="active-link" ariaCurrentWhenActive="page">Game</a>
       <a routerLink="/blog" routerLinkActive="active-link" ariaCurrentWhenActive="page">Blog</a>
       <a
         routerLink="/recipesensei"

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { AboutPageComponent } from './pages/about-page/about-page.component';
 import { BlogPostPageComponent } from './pages/blog-post-page/blog-post-page.component';
 import { GalleryPageComponent } from './pages/gallery-page/gallery-page.component';
+import { GamePageComponent } from './pages/game-page/game-page.component';
 import { HomePageComponent } from './pages/home-page/home-page.component';
 import { RecipeSenseiPageComponent } from './pages/recipesensei-page/recipesensei-page.component';
 import { RecipeSenseiPrivacyPageComponent } from './pages/recipesensei-privacy-page/recipesensei-privacy-page.component';
@@ -12,6 +13,7 @@ import { SubmitPageComponent } from './pages/submit-page/submit-page.component';
 export const routes: Routes = [
   { path: '', component: HomePageComponent },
   { path: 'gallery', component: GalleryPageComponent },
+  { path: 'game', component: GamePageComponent },
   { path: 'blog', component: RecipesPageComponent },
   { path: 'blog/:slug', component: BlogPostPageComponent },
   { path: 'recipes', redirectTo: 'blog', pathMatch: 'full' },

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -30,6 +30,12 @@ const PAGE_METADATA: Record<string, PageMetadata> = {
       "Browse Drake's Food photos, including smoked meats, backyard pizza, family meals, and home-cooking experiments.",
     canonicalPath: '/gallery',
   },
+  '/game': {
+    title: "Frying Pan Food Catch Game | Drake's Food",
+    description:
+      "Play a tiny Drake's Food browser game: move the frying pan, catch the good food, and dodge the rotten stuff.",
+    canonicalPath: '/game',
+  },
   '/blog': {
     title: "Drake's Food Blog | Drake's Food",
     description:

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -4,6 +4,7 @@
   </p>
   <nav class="footer-links" aria-label="Footer links">
     <a class="footer-link" routerLink="/gallery">Gallery</a>
+    <a class="footer-link" routerLink="/game">Game</a>
     <a class="footer-link" routerLink="/blog">Blog</a>
     <a class="footer-link" routerLink="/about">About</a>
     <a

--- a/src/app/pages/game-page/game-page.component.css
+++ b/src/app/pages/game-page/game-page.component.css
@@ -76,11 +76,11 @@
     linear-gradient(135deg, rgba(255, 250, 245, 0.92), rgba(238, 231, 251, 0.72)),
     var(--color-surface);
   box-shadow: var(--shadow-photo);
-  touch-action: none;
 }
 
 .game-stage.is-playing {
   cursor: none;
+  touch-action: none;
 }
 
 .game-canvas {

--- a/src/app/pages/game-page/game-page.component.css
+++ b/src/app/pages/game-page/game-page.component.css
@@ -1,0 +1,150 @@
+.game-page {
+  padding: 2rem 0 4rem;
+}
+
+.game-hero {
+  display: grid;
+  gap: 1.5rem;
+  align-items: end;
+  margin-bottom: 1.5rem;
+}
+
+.game-copy {
+  display: grid;
+  gap: 1rem;
+  max-width: 760px;
+}
+
+.game-copy h1 {
+  margin: 0;
+  max-width: 760px;
+  font-size: clamp(2rem, 10vw, 5.4rem);
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+  overflow-wrap: anywhere;
+}
+
+.game-copy p:not(.eyebrow) {
+  max-width: 690px;
+  color: var(--color-text-muted);
+  font-size: clamp(1rem, 2vw, 1.18rem);
+  line-height: 1.8;
+}
+
+.game-scoreboard {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  border: 1px solid rgba(109, 74, 163, 0.14);
+  border-radius: 1rem;
+  background: var(--color-surface);
+  padding: 0.75rem;
+  box-shadow: var(--shadow-card);
+}
+
+.game-scoreboard div {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+  border-radius: 0.7rem;
+  background: rgba(109, 74, 163, 0.08);
+  padding: 0.65rem 0.45rem;
+  text-align: center;
+}
+
+.game-scoreboard span {
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.game-scoreboard strong {
+  color: var(--color-purple-dark);
+  font-size: clamp(1.35rem, 4vw, 2rem);
+  line-height: 1;
+}
+
+.game-stage {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  max-width: 100%;
+  border: 1px solid rgba(109, 74, 163, 0.16);
+  border-radius: 1.6rem;
+  background:
+    linear-gradient(135deg, rgba(255, 250, 245, 0.92), rgba(238, 231, 251, 0.72)),
+    var(--color-surface);
+  box-shadow: var(--shadow-photo);
+  touch-action: none;
+}
+
+.game-stage.is-playing {
+  cursor: none;
+}
+
+.game-canvas {
+  display: block;
+  width: 100%;
+  height: clamp(22rem, 45vh, 32rem);
+}
+
+.game-overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: rgba(255, 250, 245, 0.74);
+  text-align: center;
+}
+
+.game-overlay h2 {
+  max-width: min(560px, 100%);
+  margin: 0 auto;
+  color: var(--color-text);
+  font-size: clamp(1.45rem, 8vw, 3.1rem);
+  line-height: 1;
+  letter-spacing: -0.02em;
+  overflow-wrap: anywhere;
+}
+
+.game-status {
+  color: var(--color-purple-dark);
+  font-size: 0.8rem;
+  font-weight: 900;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.game-overlay .button {
+  justify-self: center;
+}
+
+.game-instructions {
+  display: grid;
+  gap: 0.6rem;
+  max-width: 840px;
+  margin: 1rem auto 0;
+  color: var(--color-text-muted);
+  line-height: 1.7;
+  text-align: center;
+}
+
+.game-instructions p:first-child {
+  color: var(--color-purple-dark);
+  font-weight: 800;
+}
+
+@media (min-width: 760px) {
+  .game-page {
+    padding-top: 3.5rem;
+  }
+
+  .game-hero {
+    grid-template-columns: minmax(0, 1fr) 340px;
+    gap: 2rem;
+    margin-bottom: 2rem;
+  }
+}

--- a/src/app/pages/game-page/game-page.component.html
+++ b/src/app/pages/game-page/game-page.component.html
@@ -1,0 +1,55 @@
+<section class="game-page" aria-labelledby="game-page-title">
+  <div class="game-hero">
+    <div class="game-copy">
+      <p class="eyebrow">Tiny kitchen rush</p>
+      <h1 id="game-page-title">Catch dinner before it hits the floor.</h1>
+      <p>
+        Move the frying pan, catch the good food, and keep the rotten stuff out of dinner.
+        It is a quick 60-second round built for keyboard, touch, and one more try.
+      </p>
+    </div>
+
+    <div class="game-scoreboard" aria-live="polite">
+      <div>
+        <span>Score</span>
+        <strong>{{ snapshot.score }}</strong>
+      </div>
+      <div>
+        <span>Time</span>
+        <strong>{{ snapshot.remainingTime }}s</strong>
+      </div>
+      <div>
+        <span>Lives</span>
+        <strong>{{ snapshot.lives }}</strong>
+      </div>
+    </div>
+  </div>
+
+  <div class="game-stage" [class.is-playing]="snapshot.status === 'playing'">
+    <canvas
+      #gameCanvas
+      class="game-canvas"
+      width="960"
+      height="620"
+      role="img"
+      aria-label="A pixel-style game where a frying pan catches falling food"
+      (pointerdown)="handlePointerMove($event)"
+      (pointermove)="handlePointerMove($event)"
+    ></canvas>
+
+    @if (snapshot.status !== 'playing') {
+      <div class="game-overlay">
+        <p class="game-status">{{ snapshot.status === 'ready' ? 'Ready?' : 'Game over' }}</p>
+        <h2>{{ snapshot.message }}</h2>
+        <button type="button" class="button button-primary" (click)="startRound()">
+          {{ snapshot.status === 'ready' ? 'Start rush' : 'Play again' }}
+        </button>
+      </div>
+    }
+  </div>
+
+  <div class="game-instructions" aria-label="Game controls">
+    <p>{{ snapshot.message }}</p>
+    <p>Keyboard: Arrow keys or A/D. Mobile: drag across the pan. Enter or Space starts a round.</p>
+  </div>
+</section>

--- a/src/app/pages/game-page/game-page.component.ts
+++ b/src/app/pages/game-page/game-page.component.ts
@@ -110,7 +110,7 @@ export class GamePageComponent implements AfterViewInit {
       this.pressedKeys.add(event.key.toLowerCase());
     }
 
-    if (event.key === 'Enter' || event.key === ' ') {
+    if ((event.key === 'Enter' || event.key === ' ') && !this.isInteractiveTarget(event.target)) {
       event.preventDefault();
       this.startRound();
     }
@@ -453,6 +453,18 @@ export class GamePageComponent implements AfterViewInit {
 
   private isControlKey(key: string): boolean {
     return ['ArrowLeft', 'ArrowRight', 'a', 'A', 'd', 'D'].includes(key);
+  }
+
+  private isInteractiveTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof Element)) {
+      return false;
+    }
+
+    return Boolean(
+      target.closest(
+        'a, button, input, select, textarea, summary, [contenteditable="true"], [role="button"], [role="link"], [role="menuitem"], [role="tab"]',
+      ),
+    );
   }
 
   private clamp(value: number, min: number, max: number): number {

--- a/src/app/pages/game-page/game-page.component.ts
+++ b/src/app/pages/game-page/game-page.component.ts
@@ -146,7 +146,7 @@ export class GamePageComponent implements AfterViewInit {
   }
 
   protected handlePointerMove(event: PointerEvent): void {
-    if (!this.canvas) {
+    if (!this.canvas || this.snapshot.status !== 'playing') {
       return;
     }
 

--- a/src/app/pages/game-page/game-page.component.ts
+++ b/src/app/pages/game-page/game-page.component.ts
@@ -1,0 +1,465 @@
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  ElementRef,
+  HostListener,
+  NgZone,
+  ViewChild,
+  inject,
+} from '@angular/core';
+
+type GameStatus = 'ready' | 'playing' | 'gameOver';
+type FallingItemKind = 'good' | 'rotten';
+
+interface FallingItem {
+  id: number;
+  x: number;
+  y: number;
+  size: number;
+  speed: number;
+  kind: FallingItemKind;
+  food: string;
+  caught: boolean;
+}
+
+interface GameSnapshot {
+  status: GameStatus;
+  score: number;
+  lives: number;
+  remainingTime: number;
+  message: string;
+}
+
+const ROUND_SECONDS = 60;
+const STARTING_LIVES = 3;
+const GOOD_FOOD_POINTS = 10;
+const ITEM_SPAWN_INTERVAL_MS = 760;
+const PAN_WIDTH = 112;
+const PAN_HEIGHT = 28;
+const PAN_Y_OFFSET = 54;
+const GOOD_FOODS = ['pizza', 'taco', 'burger', 'strawberry', 'egg'];
+const ROTTEN_FOODS = ['moldy', 'burnt'];
+
+@Component({
+  selector: 'app-game-page',
+  standalone: true,
+  templateUrl: './game-page.component.html',
+  styleUrls: ['./game-page.component.css'],
+})
+export class GamePageComponent implements AfterViewInit {
+  @ViewChild('gameCanvas', { static: true })
+  private readonly gameCanvas?: ElementRef<HTMLCanvasElement>;
+
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly ngZone = inject(NgZone);
+
+  protected snapshot: GameSnapshot = {
+    status: 'ready',
+    score: 0,
+    lives: STARTING_LIVES,
+    remainingTime: ROUND_SECONDS,
+    message: 'Catch the good stuff. Dodge the rotten stuff.',
+  };
+
+  private animationFrameId = 0;
+  private canvas?: HTMLCanvasElement;
+  private context?: CanvasRenderingContext2D;
+  private gameStartedAt = 0;
+  private itemSequence = 0;
+  private items: FallingItem[] = [];
+  private lastFrameAt = 0;
+  private lastHudUpdateAt = 0;
+  private lastSpawnAt = 0;
+  private panX = 0;
+  private readonly pressedKeys = new Set<string>();
+  private resizeObserver?: ResizeObserver;
+
+  ngAfterViewInit(): void {
+    const canvas = this.gameCanvas?.nativeElement;
+    const context = canvas?.getContext('2d');
+
+    if (!canvas || !context) {
+      return;
+    }
+
+    this.canvas = canvas;
+    this.context = context;
+    this.resizeCanvas();
+    this.resetRound();
+    this.draw();
+
+    this.resizeObserver = new ResizeObserver(() => {
+      this.resizeCanvas();
+      this.draw();
+    });
+    this.resizeObserver.observe(canvas);
+
+    this.destroyRef.onDestroy(() => {
+      this.stopLoop();
+      this.resizeObserver?.disconnect();
+    });
+  }
+
+  @HostListener('window:keydown', ['$event'])
+  protected handleKeyDown(event: KeyboardEvent): void {
+    if (this.isControlKey(event.key)) {
+      event.preventDefault();
+      this.pressedKeys.add(event.key.toLowerCase());
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.startRound();
+    }
+  }
+
+  @HostListener('window:keyup', ['$event'])
+  protected handleKeyUp(event: KeyboardEvent): void {
+    this.pressedKeys.delete(event.key.toLowerCase());
+  }
+
+  protected startRound(): void {
+    if (this.snapshot.status === 'playing') {
+      return;
+    }
+
+    this.resetRound();
+    this.snapshot = {
+      status: 'playing',
+      score: 0,
+      lives: STARTING_LIVES,
+      remainingTime: ROUND_SECONDS,
+      message: 'Kitchen rush is on.',
+    };
+    this.changeDetectorRef.markForCheck();
+
+    this.ngZone.runOutsideAngular(() => {
+      this.lastFrameAt = performance.now();
+      this.gameStartedAt = this.lastFrameAt;
+      this.lastHudUpdateAt = this.lastFrameAt;
+      this.lastSpawnAt = this.lastFrameAt - ITEM_SPAWN_INTERVAL_MS;
+      this.animationFrameId = requestAnimationFrame(this.tick);
+    });
+  }
+
+  protected handlePointerMove(event: PointerEvent): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    const bounds = this.canvas.getBoundingClientRect();
+    const x = event.clientX - bounds.left;
+    this.panX = this.clamp(x, PAN_WIDTH / 2, bounds.width - PAN_WIDTH / 2);
+  }
+
+  private readonly tick = (now: number): void => {
+    const elapsed = Math.min((now - this.lastFrameAt) / 1000, 0.04);
+    this.lastFrameAt = now;
+
+    this.update(elapsed, now);
+    this.draw();
+
+    if (this.snapshot.status === 'playing') {
+      this.animationFrameId = requestAnimationFrame(this.tick);
+    }
+  };
+
+  private update(elapsedSeconds: number, now: number): void {
+    const canvas = this.canvas;
+
+    if (!canvas || this.snapshot.status !== 'playing') {
+      return;
+    }
+
+    const bounds = canvas.getBoundingClientRect();
+    const moveDirection =
+      Number(this.pressedKeys.has('arrowright') || this.pressedKeys.has('d')) -
+      Number(this.pressedKeys.has('arrowleft') || this.pressedKeys.has('a'));
+    this.panX = this.clamp(this.panX + moveDirection * 420 * elapsedSeconds, PAN_WIDTH / 2, bounds.width - PAN_WIDTH / 2);
+
+    if (now - this.lastSpawnAt >= ITEM_SPAWN_INTERVAL_MS) {
+      this.spawnItem(bounds.width);
+      this.lastSpawnAt = now;
+    }
+
+    const panTop = bounds.height - PAN_Y_OFFSET - PAN_HEIGHT / 2;
+    const panLeft = this.panX - PAN_WIDTH / 2;
+    const panRight = this.panX + PAN_WIDTH / 2;
+
+    for (const item of this.items) {
+      item.y += item.speed * elapsedSeconds;
+
+      const itemBottom = item.y + item.size / 2;
+      const itemLeft = item.x - item.size / 2;
+      const itemRight = item.x + item.size / 2;
+      const overlapsPan =
+        itemBottom >= panTop &&
+        item.y <= panTop + PAN_HEIGHT &&
+        itemRight >= panLeft &&
+        itemLeft <= panRight;
+
+      if (overlapsPan && !item.caught) {
+        item.caught = true;
+
+        if (item.kind === 'good') {
+          this.snapshot.score += GOOD_FOOD_POINTS;
+          this.snapshot.message = `${this.capitalize(item.food)} saved.`;
+        } else {
+          this.snapshot.lives -= 1;
+          this.snapshot.message = 'Rotten bite. One pan life gone.';
+        }
+      }
+    }
+
+    this.items = this.items.filter((item) => !item.caught && item.y - item.size / 2 <= bounds.height + 24);
+
+    const remainingTime = Math.max(0, ROUND_SECONDS - Math.floor((now - this.gameStartedAt) / 1000));
+
+    if (remainingTime !== this.snapshot.remainingTime || now - this.lastHudUpdateAt > 250) {
+      this.snapshot.remainingTime = remainingTime;
+      this.lastHudUpdateAt = now;
+      this.ngZone.run(() => this.changeDetectorRef.markForCheck());
+    }
+
+    if (this.snapshot.lives <= 0) {
+      this.endRound('The pan tapped out. Give it one more run?');
+      return;
+    }
+
+    if (remainingTime <= 0) {
+      this.endRound(`Time. Final score: ${this.snapshot.score}.`);
+    }
+  }
+
+  private endRound(message: string): void {
+    this.snapshot = {
+      ...this.snapshot,
+      status: 'gameOver',
+      remainingTime: Math.max(0, this.snapshot.remainingTime),
+      message,
+    };
+    this.stopLoop();
+    this.ngZone.run(() => this.changeDetectorRef.markForCheck());
+  }
+
+  private resetRound(): void {
+    const width = this.canvas?.getBoundingClientRect().width ?? 720;
+
+    this.items = [];
+    this.itemSequence = 0;
+    this.panX = width / 2;
+    this.pressedKeys.clear();
+  }
+
+  private spawnItem(width: number): void {
+    const isRotten = Math.random() < 0.22;
+    const foods = isRotten ? ROTTEN_FOODS : GOOD_FOODS;
+    const size = isRotten ? 32 : 34 + Math.random() * 8;
+
+    this.items.push({
+      id: this.itemSequence,
+      x: 32 + Math.random() * Math.max(width - 64, 1),
+      y: -size,
+      size,
+      speed: 132 + Math.random() * 88 + Math.min(this.snapshot.score * 0.8, 90),
+      kind: isRotten ? 'rotten' : 'good',
+      food: foods[this.itemSequence % foods.length],
+      caught: false,
+    });
+    this.itemSequence += 1;
+  }
+
+  private resizeCanvas(): void {
+    const canvas = this.canvas;
+
+    if (!canvas) {
+      return;
+    }
+
+    const bounds = canvas.getBoundingClientRect();
+    const pixelRatio = window.devicePixelRatio || 1;
+    canvas.width = Math.max(Math.floor(bounds.width * pixelRatio), 1);
+    canvas.height = Math.max(Math.floor(bounds.height * pixelRatio), 1);
+    this.context?.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+    this.panX = this.clamp(this.panX || bounds.width / 2, PAN_WIDTH / 2, bounds.width - PAN_WIDTH / 2);
+  }
+
+  private draw(): void {
+    const canvas = this.canvas;
+    const context = this.context;
+
+    if (!canvas || !context) {
+      return;
+    }
+
+    const bounds = canvas.getBoundingClientRect();
+    context.clearRect(0, 0, bounds.width, bounds.height);
+    this.drawKitchen(context, bounds.width, bounds.height);
+
+    for (const item of this.items) {
+      this.drawFood(context, item);
+    }
+
+    this.drawPan(context, this.panX, bounds.height - PAN_Y_OFFSET);
+
+    if (this.snapshot.status !== 'playing') {
+      this.drawIdleSparkle(context, bounds.width, bounds.height);
+    }
+  }
+
+  private drawKitchen(context: CanvasRenderingContext2D, width: number, height: number): void {
+    const tileSize = 24;
+
+    context.fillStyle = '#fffaf5';
+    context.fillRect(0, 0, width, height);
+    context.fillStyle = '#f1dfd0';
+
+    for (let y = 0; y < height; y += tileSize) {
+      for (let x = (y / tileSize) % 2 === 0 ? 0 : tileSize / 2; x < width; x += tileSize) {
+        context.fillRect(x, y, tileSize / 2, tileSize / 2);
+      }
+    }
+
+    context.fillStyle = 'rgba(109, 74, 163, 0.1)';
+    context.fillRect(0, height - 84, width, 84);
+    context.fillStyle = 'rgba(140, 90, 64, 0.14)';
+    context.fillRect(0, height - 78, width, 8);
+  }
+
+  private drawPan(context: CanvasRenderingContext2D, x: number, y: number): void {
+    context.save();
+    context.translate(Math.round(x), Math.round(y));
+    context.fillStyle = '#302520';
+    context.fillRect(-PAN_WIDTH / 2, -PAN_HEIGHT / 2, PAN_WIDTH, PAN_HEIGHT);
+    context.fillStyle = '#4a3930';
+    context.fillRect(-PAN_WIDTH / 2 + 8, -PAN_HEIGHT / 2 + 5, PAN_WIDTH - 16, PAN_HEIGHT - 10);
+    context.fillStyle = '#8c5a40';
+    context.fillRect(PAN_WIDTH / 2 - 2, -6, 58, 12);
+    context.fillStyle = '#f7efe7';
+    context.fillRect(-24, -5, 48, 10);
+    context.restore();
+  }
+
+  private drawFood(context: CanvasRenderingContext2D, item: FallingItem): void {
+    context.save();
+    context.translate(Math.round(item.x), Math.round(item.y));
+
+    if (item.food === 'pizza') {
+      context.fillStyle = '#c36b2f';
+      this.pixelTriangle(context, item.size);
+      context.fillStyle = '#f6d86b';
+      context.fillRect(-item.size / 2 + 8, -item.size / 2 + 8, item.size - 18, 7);
+      context.fillRect(-item.size / 2 + 10, -item.size / 2 + 15, item.size - 24, 7);
+      context.fillStyle = '#b83e35';
+      context.fillRect(-10, -7, 6, 6);
+      context.fillRect(2, -1, 6, 6);
+      context.fillRect(-14, 7, 5, 5);
+    } else if (item.food === 'taco') {
+      context.fillStyle = '#f0b95f';
+      context.fillRect(-item.size / 2, -2, item.size, item.size / 2);
+      context.fillStyle = '#3f7d3c';
+      context.fillRect(-item.size / 3, -10, item.size / 1.5, 10);
+      context.fillStyle = '#7d4c35';
+      context.fillRect(-10, -4, 20, 7);
+    } else if (item.food === 'burger') {
+      context.fillStyle = '#d9984d';
+      context.fillRect(-item.size / 2, -12, item.size, 10);
+      context.fillStyle = '#7d4c35';
+      context.fillRect(-item.size / 2, -1, item.size, 8);
+      context.fillStyle = '#3f7d3c';
+      context.fillRect(-item.size / 2, 8, item.size, 5);
+      context.fillStyle = '#e1b85a';
+      context.fillRect(-item.size / 2, 14, item.size, 8);
+    } else if (item.food === 'strawberry') {
+      context.fillStyle = '#c83f46';
+      context.fillRect(-12, -10, 24, 24);
+      context.fillStyle = '#3f7d3c';
+      context.fillRect(-6, -16, 12, 8);
+      context.fillStyle = '#fff3a3';
+      context.fillRect(-5, -1, 3, 3);
+      context.fillRect(5, 7, 3, 3);
+    } else if (item.food === 'egg') {
+      context.fillStyle = '#fff8df';
+      context.fillRect(-15, -12, 30, 24);
+      context.fillStyle = '#efb246';
+      context.fillRect(-6, -5, 12, 12);
+    } else {
+      this.drawRottenFood(context, item);
+    }
+
+    context.restore();
+  }
+
+  private drawIdleSparkle(context: CanvasRenderingContext2D, width: number, height: number): void {
+    context.fillStyle = 'rgba(61, 37, 111, 0.18)';
+    context.fillRect(width * 0.2, height * 0.2, 8, 8);
+    context.fillRect(width * 0.74, height * 0.34, 10, 10);
+    context.fillRect(width * 0.38, height * 0.56, 6, 6);
+  }
+
+  private drawRottenFood(context: CanvasRenderingContext2D, item: FallingItem): void {
+    if (item.food === 'burnt') {
+      context.fillStyle = '#201815';
+      context.fillRect(-15, -12, 28, 24);
+      context.fillRect(-10, -18, 18, 8);
+      context.fillRect(-19, -4, 8, 14);
+      context.fillStyle = '#5a3224';
+      context.fillRect(-9, -8, 17, 7);
+      context.fillRect(-1, 4, 13, 6);
+      context.fillStyle = '#f08b3e';
+      context.fillRect(-13, -13, 5, 5);
+      context.fillRect(8, -2, 4, 4);
+      context.fillStyle = '#16100e';
+      context.fillRect(-4, -18, 5, 36);
+      return;
+    }
+
+    context.fillStyle = '#556533';
+    context.fillRect(-14, -14, 24, 10);
+    context.fillRect(-18, -6, 34, 18);
+    context.fillRect(-10, 10, 20, 8);
+    context.fillStyle = '#9fb554';
+    context.fillRect(-8, -10, 9, 7);
+    context.fillRect(5, 1, 8, 8);
+    context.fillRect(-15, 5, 6, 6);
+    context.fillStyle = '#2f3b22';
+    context.fillRect(-4, -1, 5, 5);
+    context.fillRect(8, -8, 5, 5);
+    context.fillRect(-12, 12, 4, 4);
+    context.fillStyle = 'rgba(85, 101, 51, 0.45)';
+    context.fillRect(-24, -24, 5, 5);
+    context.fillRect(18, -19, 4, 4);
+    context.fillRect(22, 6, 5, 5);
+  }
+
+  private pixelTriangle(context: CanvasRenderingContext2D, size: number): void {
+    context.beginPath();
+    context.moveTo(-size / 2, -size / 2);
+    context.lineTo(size / 2, -size / 4);
+    context.lineTo(-size / 3, size / 2);
+    context.closePath();
+    context.fill();
+  }
+
+  private stopLoop(): void {
+    if (this.animationFrameId) {
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = 0;
+    }
+  }
+
+  private isControlKey(key: string): boolean {
+    return ['ArrowLeft', 'ArrowRight', 'a', 'A', 'd', 'D'].includes(key);
+  }
+
+  private clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  private capitalize(value: string): string {
+    return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -82,7 +82,7 @@ button:focus-visible,
 }
 
 section {
-  width: min(1200px, calc(100% - 2rem));
+  width: min(1200px, calc(100vw - 2rem));
   margin: 0 auto;
 }
 
@@ -138,7 +138,7 @@ p {
 
 @media (min-width: 900px) {
   section {
-    width: min(1120px, calc(100% - 4rem));
+    width: min(1120px, calc(100vw - 4rem));
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -82,7 +82,7 @@ button:focus-visible,
 }
 
 section {
-  width: min(1200px, calc(100vw - 2rem));
+  width: min(1200px, calc(100% - 2rem));
   margin: 0 auto;
 }
 
@@ -138,7 +138,7 @@ p {
 
 @media (min-width: 900px) {
   section {
-    width: min(1120px, calc(100vw - 4rem));
+    width: min(1120px, calc(100% - 4rem));
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a public `/game` route with a lightweight canvas frying-pan food-catch game.
- Wire the route into navigation, footer links, runtime metadata, generated route HTML, and the sitemap.
- Add keyboard and pointer/touch controls, score/time/lives state, start/game-over/restart flow, and clearer food sprites including polished pizza and rotten-food drawings.

Closes #112

## Validation
- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run build` passed.

Local commands ran under Node `v25.9.0`, which prints Angular's odd-numbered Node warning, but validation completed successfully.

## Visual Review
- Ran local Chrome visual smoke checks for desktop and mobile `/game` layout.
- Checked active gameplay, restart flow, generated `/game/index.html`, and updated pizza/rotten-food sprites.
- Confirmed the local dev server and headless Chrome QA processes were stopped after review.

## Notes
- No backend, account, leaderboard, analytics, or new game-engine dependency was added.
- The game remains static-site friendly and canvas-rendered inside Angular.